### PR TITLE
feat: Claude 4.7 Opus + pymupdf extraction + Claude Code SDK routing

### DIFF
--- a/dissertation_pdf_mapping.json
+++ b/dissertation_pdf_mapping.json
@@ -1,0 +1,928 @@
+{
+  "_scope_note": "filename -> paper mapping only. NOT a verbatim/citation-chain source. Dissertation citation log verification is owned by the dissertation's own pymupdf -> citation_log_gate pipeline.",
+  "scan_roots": [
+    "data\\raw",
+    "data\\processed",
+    "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw",
+    "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\processed"
+  ],
+  "total_pdfs_scanned": 1253,
+  "candidates": {
+    "debole2025": [
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\1-s2.0-S2772949425000026-main.pdf",
+        "score": 2.0,
+        "title": "Overview of emerging electronics technologies for artificial intelligence: A review",
+        "authors": [
+          "Materials Today Electronics 11 (2025) 100136",
+          "Peng Gao a, Muhammad Adnan b,c,*",
+          "a Communication",
+          "Information Engineering",
+          "Chongqing College of Mobile Communication",
+          "Chongqing 401520",
+          "PR China"
+        ],
+        "doi": "10.1016/j.mtelec.2025.100136",
+        "year": 2025,
+        "page_count": 21,
+        "reasons": [
+          "year 2025 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\2025.07.22.664908v1.full.pdf",
+        "score": 2.0,
+        "title": "Many-Two-One: Diverse Representations Across Visual Pathways Emerge from A Single Objective",
+        "authors": [
+          "Across Visual Pathways Emerge from A",
+          "Single Objective",
+          "Yingtian Tang1, , Abdulkadir Gokce1, , Khaled Jedoui Al-Karkari2, Daniel Yamins2, and Martin Schrimpf1,",
+          "divides visual processing into distinct \"what\"",
+          "\"where/how\" streams \u2013 however",
+          "their origin and"
+        ],
+        "doi": "10.1101/2025.07.22.664908",
+        "year": 2025,
+        "page_count": 27,
+        "reasons": [
+          "year 2025 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\2025.09.22.677855.full.pdf",
+        "score": 2.0,
+        "title": "Neuronal signatures of successful one-shot memory in mid-level visual cortex",
+        "authors": [
+          "Affiliation: Department of Neurobiology",
+          "Neuroscience Institute",
+          "University of Chicago,"
+        ],
+        "doi": "10.1101/2025.09.22.677855",
+        "year": 2025,
+        "page_count": 33,
+        "reasons": [
+          "year 2025 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\2503.19953v1.pdf",
+        "score": 2.0,
+        "title": "Self-Supervised Learning of Motion Concepts by Optimizing Counterfactuals",
+        "authors": [
+          "Stefan Stojanov*",
+          "David Wendt*",
+          "Seungwoo Kim*",
+          "Rahul Venkatesh*",
+          "Kevin Feigelis",
+          "Jiajun Wu",
+          "Stanford University"
+        ],
+        "doi": null,
+        "year": 2025,
+        "page_count": 16,
+        "reasons": [
+          "year 2025 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\80_Understanding_Human_Limits_.pdf",
+        "score": 2.0,
+        "title": "Understanding Human Limits in Pattern Recognition: A Computational Model of Sequential Reasoning in Rock, Paper, Scissors",
+        "authors": [
+          "Understanding Human Limits in Pattern Recognition: A Computational Model of",
+          "Sequential Reasoning in Rock, Paper, Scissors",
+          "Logan Cross1*, Erik Brockbank2*, Tobias Gerstenberg2, Judith E. Fan2, Daniel L. K. Yamins2, Nick Haber3"
+        ],
+        "doi": null,
+        "year": 2025,
+        "page_count": 17,
+        "reasons": [
+          "year 2025 exact match"
+        ]
+      }
+    ],
+    "khalighrazavi2014": [
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\1-s2.0-S0893608012003206-main.pdf",
+        "score": 2.0,
+        "title": "Adaptive filters and internal models: Multilevel description of cerebellar function",
+        "authors": [
+          "Neural Networks 47 (2013) 134\u2013149",
+          "Neural Networks",
+          "Adaptive filters",
+          "internal models: Multilevel description of cerebellar",
+          "John Porrill a, Paul Dean a,\u2217, Sean R. Anderson b",
+          "b Department of Automatic Control",
+          "Systems Engineering",
+          "Sheffield University",
+          "Sheffield",
+          "S1 3JD",
+          "Cerebellar function is increasingly discussed in terms of engineering schemes for motor control",
+          "signal",
+          "processing that involve internal models. To address the relation between the cerebellum",
+          "internal"
+        ],
+        "doi": "10.1016/j.neunet.2012.12.005",
+        "year": 2014,
+        "page_count": 16,
+        "reasons": [
+          "year 2014 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\frontiers2014_threestage_memory.pdf",
+        "score": 2.0,
+        "title": "Memory consolidation from seconds to weeks: a three-stage neural network model with autonomous reinstatement dynamics",
+        "authors": [
+          "Florian Fiebig 1,2 and Anders Lansner 1,3*",
+          "2 Institute for Adaptive",
+          "Neural Computation",
+          "School of Informatics",
+          "Edinburgh University",
+          "Edinburgh",
+          "Scotland",
+          "3 Department of Numerical Analysis",
+          "Computer Science",
+          "Stockholm University",
+          "Stockholm",
+          "Sweden",
+          "California Los Angeles, USA",
+          "Goren Gordon, Weizmann Institute",
+          "Emili Balaguer-Ballester,",
+          "Bournemouth University, UK",
+          "Anders Lansner, Department of"
+        ],
+        "doi": "10.3389/fncom.2014.00064",
+        "year": 2014,
+        "page_count": 17,
+        "reasons": [
+          "year 2014 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\horowitz2014_computing_energy.pdf",
+        "score": 2.0,
+        "title": "Computing's Energy Problem (and what we can do about it)",
+        "authors": [
+          "Mark Horowitz",
+          "Departments of Electrical Engineering",
+          "Computer Science,",
+          "Stanford University, Stanford, CA"
+        ],
+        "doi": null,
+        "year": 2014,
+        "page_count": 5,
+        "reasons": [
+          "year 2014 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\huys2014_mbmf.pdf",
+        "score": 2.0,
+        "title": "Reward-Based Learning, Model-Based and Model-Free",
+        "authors": [
+          "Reward-Based Learning",
+          "Model-Based",
+          "Model-Free",
+          "Quentin J. M. Huysa,b*",
+          "Anthony Cruickshankc",
+          "Peggy Seri\u00e8sc",
+          "aTranslational Neuromodeling Unit",
+          "Institute of Biomedical Engineering",
+          "ETH Z\u20acurich",
+          "University of Z\u20acurich",
+          "Z\u20acurich,",
+          "bDepartment of Psychiatry",
+          "Psychotherapy",
+          "Psychosomatics",
+          "Hospital of Psychiatry",
+          "University of Z\u20acurich",
+          "Z\u20acurich,",
+          "cInstitute of Adaptive",
+          "Neural Computation",
+          "University of Edinburgh",
+          "Edinburgh",
+          "such that actions take into account both immediate",
+          "delayed consequences. They fall into two",
+          "broad classes. Model-based approaches assume an explicit model of the environment",
+          "the agent.",
+          "The model describes the consequences of actions",
+          "the associated returns. From this",
+          "optimal",
+          "explicit knowledge of the dynamics of the environment or the consequences of actions",
+          "evaluate",
+          "Detailed Description"
+        ],
+        "doi": "10.1007/978-1-4614-7320-6_674-1",
+        "year": 2014,
+        "page_count": 10,
+        "reasons": [
+          "year 2014 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\oizumi2014_iit3.pdf",
+        "score": 2.0,
+        "title": "pcbi.1003588 1..25",
+        "authors": [
+          "Masafumi Oizumi1,2., Larissa Albantakis1., Giulio Tononi1*"
+        ],
+        "doi": "10.1371/journal.pcbi.1003588",
+        "year": 2014,
+        "page_count": 25,
+        "reasons": [
+          "year 2014 exact match"
+        ]
+      }
+    ],
+    "appuswamy2024": [
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\1-s2.0-S0896627324002794-main.pdf",
+        "score": 2.0,
+        "title": "A unifying framework for functional organization in early and higher ventral visual cortex",
+        "authors": [
+          "early",
+          "higher ventral visual cortex",
+          "d Single model predicts function",
+          "spatial structure in early",
+          "d Best model uses self-supervised learning",
+          "a scalable",
+          "Eshed Margalit, Hyodong Lee,",
+          "Dawn Finzi, James J. DiCarlo,",
+          "Kalanit Grill-Spector,"
+        ],
+        "doi": "10.1016/j.neuron.2024.04.018",
+        "year": 2024,
+        "page_count": 25,
+        "reasons": [
+          "year 2024 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\1301.3530v2.pdf",
+        "score": 2.0,
+        "title": "The Neural Representation Benchmark and its",
+        "authors": [
+          "The Neural Representation Benchmark and its",
+          "Evaluation on Brain",
+          "Machine",
+          "Department of Brain",
+          "Cognitive Sciences",
+          "Massachusetts Institute of Technology"
+        ],
+        "doi": null,
+        "year": 2024,
+        "page_count": 16,
+        "reasons": [
+          "year 2024 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\2023_Patent_US20240082534A1.pdf",
+        "score": 2.0,
+        "title": "US020240082534A120240314",
+        "authors": [
+          "Unknown Author"
+        ],
+        "doi": null,
+        "year": 2024,
+        "page_count": 51,
+        "reasons": [
+          "year 2024 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\2407.07086v2.pdf",
+        "score": 2.0,
+        "title": "Published as a conference paper at ICLR 2025",
+        "authors": [
+          "Logan Cross1\u2217",
+          "Violet Xiang2",
+          "Agam Bhatia1",
+          "Nick Haber3",
+          "Stanford University"
+        ],
+        "doi": null,
+        "year": 2024,
+        "page_count": 40,
+        "reasons": [
+          "year 2024 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\33_Inter_animal_transforms_as_.pdf",
+        "score": 2.0,
+        "title": "To appear at the ICLR 2024 Workshop on Representational Alignment (Re-Align)",
+        "authors": [
+          "Imran Thobani",
+          "Stanford University"
+        ],
+        "doi": null,
+        "year": 2024,
+        "page_count": 12,
+        "reasons": [
+          "year 2024 exact match"
+        ]
+      }
+    ],
+    "friston2005": [
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\bastos-canonical-microcircuits.pdf",
+        "score": 3.0,
+        "title": "Canonical microcircuits for predictive coding",
+        "authors": [
+          "Fries6,7",
+          "Karl J. Friston8",
+          "Germany. 7Donders Institute for Brain",
+          "Cognition",
+          "Behaviour",
+          "Radboud University Nijmegen,",
+          "University College London, Queen Square, London WC1N 3BG, UK.",
+          "microcircuitry",
+          "the functional logic of neuronal computations. We revisit the established idea"
+        ],
+        "doi": "10.1016/j.neuron.2012.10.038",
+        "year": 2013,
+        "page_count": 30,
+        "reasons": [
+          "author 'friston' in metadata"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\Research-Papers\\ProQuest-Psychology\\Artificial_Musical_Minds_The_.pdf",
+        "score": 3.0,
+        "title": "Artificial Musical Minds: The Helmholtz Machine and Expressive Music Generation",
+        "authors": [
+          "Artificial Musical Minds: The Helmholtz Machine and Expressive Music Generation",
+          "Jingwei Liu",
+          "Professor Shlomo Dubnov, Chair",
+          "Professor Gert Cauwenberghs",
+          "Professor Sanjoy Dasgupta",
+          "Professor Karl Friston",
+          "Professor Miller Puckette"
+        ],
+        "doi": null,
+        "year": 2025,
+        "page_count": 106,
+        "reasons": [
+          "author 'friston' in metadata"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\daw2005_princeton.pdf",
+        "score": 2.0,
+        "title": "npgrj_nn_1560 1704..1711",
+        "authors": [
+          "A broad range of neural",
+          "behavioral data suggests that the brain contains multiple systems for behavioral choice",
+          "including",
+          "one associated with prefrontal cortex",
+          "another with dorsolateral striatum. However",
+          "such a surfeit of control raises an additional",
+          "simplicity against the \ufb02exible",
+          "statistically ef\ufb01cient use of experience. The trade-off is realized in a competition between the",
+          "dorsolateral striatal",
+          "prefrontal systems. We suggest a Bayesian principle of arbitration between them according to uncertainty,",
+          "of actions. Their differential",
+          "integrative roles are under active",
+          "examination",
+          "an important hypothesis is that subparts of these",
+          "regions subserve two largely distinct",
+          "parallel routes to action. Such"
+        ],
+        "doi": "10.1038/nn1560",
+        "year": 2005,
+        "page_count": 8,
+        "reasons": [
+          "year 2005 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\floyer-lea-matthews-2005-distinguishable-brain-activation-networks-for-short-and-long-term-motor-skill-learning.pdf",
+        "score": 2.0,
+        "title": "Distinguishable Brain Activation Networks for Short- and Long-Term Motor Skill Learning",
+        "authors": [
+          "Distinguishable Brain Activation Networks for Short- and Long-Term Motor",
+          "Skill Learning",
+          "A. Floyer-Lea and P. M. Matthews",
+          "Floyer-Lea",
+          "P. M. Matthews. Distinguishable brain activa-",
+          "tion networks for short-",
+          "long-term motor skill learning. J Neuro-",
+          "performance improves rapidly",
+          "subsequently by a long-term,"
+        ],
+        "doi": "10.1152/jn.00717.2004",
+        "year": 2005,
+        "page_count": 7,
+        "reasons": [
+          "year 2005 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\Research-Papers\\dissertation-ch1-additions\\Lehericy_etal_2005_PNAS_BG_motor_sequence.pdf",
+        "score": 2.0,
+        "title": "Distinct basal ganglia territories are engaged in early",
+        "authors": [
+          "Kamil Ugurbil*, and Julien Doyon\u2021\u00b6",
+          "Institut National de la Sante\u00b4 et de la Recherche Me\u00b4dicale\u0001University of Paris 6, Centre Hospitalier Universitaire Pitie\u00b4-Salpe\u02c6trie`re, 75013 Paris, France; \u00a7Brain",
+          "Sciences Center, Veterans Affairs Medical Center, Minneapolis, MN 55417; and \u00b6Department of Psychology, Functional Neuroimaging Unit, University of",
+          "Edited by Leslie G. Ungerleider",
+          "National Institutes of Health",
+          "Bethesda",
+          "approved July 11",
+          "2005 (received for review April 4",
+          "2005)",
+          "MRI sessions were performed on days 1",
+          "28. In both"
+        ],
+        "doi": null,
+        "year": 2005,
+        "page_count": 6,
+        "reasons": [
+          "year 2005 exact match"
+        ]
+      }
+    ],
+    "kar2019": [
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\Research-Papers\\EBSCO\\NOV-3\\EBSCO-FullText-11_03_2025 (64).pdf",
+        "score": 5.0,
+        "title": "Beyond core object recognition: Recurrent processes account for object recognition under occlusion",
+        "authors": [
+          "Karim Rajaei1, Yalda MohsenzadehID2, Reza EbrahimpourID1,3*, Seyed-Mahdi Khaligh-",
+          "Tehran",
+          "Iran",
+          "2 Computer Science",
+          "AI Lab (CSAIL)",
+          "Cambridge",
+          "Massachusetts",
+          "United States of",
+          "America",
+          "3 Cognitive Science Research Lab.",
+          "Department of Electrical",
+          "Computer Engineering",
+          "Shahid",
+          "Rajaee Teacher Training University, Tehran, Iran, 4 Department of Brain and Cognitive Sciences, Cell",
+          "Science Research Center, Royan Institute for Stem Cell Biology and Technology, ACECR, Tehran, Iran"
+        ],
+        "doi": "10.1371/journal.pcbi.1007001",
+        "year": 2019,
+        "page_count": 31,
+        "reasons": [
+          "author 'kar' in metadata",
+          "year 2019 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\Research-Papers\\OpenAccess\\gk7764.pdf",
+        "score": 5.0,
+        "title": "Lift-the-\ufb02ap: what, where and when for",
+        "authors": [
+          "Lift-the-\ufb02ap: what",
+          "where",
+          "when for",
+          "Mengmi Zhang1",
+          "Claire Tseng2",
+          "Karla Montejo3",
+          "Joseph Kwon4",
+          "Gabriel Kreiman1"
+        ],
+        "doi": null,
+        "year": 2019,
+        "page_count": 17,
+        "reasons": [
+          "author 'kar' in metadata",
+          "year 2019 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\2023.KarDiCarlo_SMART_arXiv.pdf",
+        "score": 4.0,
+        "title": "The Quest for an",
+        "authors": [
+          "The Quest for an",
+          "Integrated Set of Neural",
+          "Mechanisms Underlying",
+          "Object Recognition in",
+          "Kohitij Kar1, and James J. DiCarlo2"
+        ],
+        "doi": null,
+        "year": 2023,
+        "page_count": 37,
+        "reasons": [
+          "author 'kar' in metadata",
+          "author 'kar' in filename"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\1807.00053v2.pdf",
+        "score": 3.75,
+        "title": "Task-Driven Convolutional Recurrent Models of the",
+        "authors": [
+          "Visual System",
+          "Aran Nayebi1,*, Daniel Bear2,*, Jonas Kubilius5,7,*, Kohitij Kar5, Surya Ganguli4,8, David",
+          "Sussillo8",
+          "James J. DiCarlo5,6",
+          "Daniel L. K. Yamins2,3,9",
+          "6Department of Brain",
+          "Cognitive Sciences",
+          "Cambridge",
+          "MA 02139",
+          "7Brain",
+          "Cognition",
+          "KU Leuven",
+          "Leuven",
+          "Belgium"
+        ],
+        "doi": null,
+        "year": 2018,
+        "page_count": 16,
+        "reasons": [
+          "author 'kar' in metadata",
+          "year 2018 within \u00b11 of 2019"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\Research-Papers\\dissertation-ch1-additions\\Rhodes_etal_2018_FrontNeuro_sPyNNaker.pdf",
+        "score": 3.75,
+        "title": "sPyNNaker: A Software Package for Running PyNN Simulations on SpiNNaker",
+        "authors": [
+          "Gert Cauwenberghs,",
+          "United States",
+          "Sandia National Laboratories (SNL),",
+          "United States",
+          "Chris Karl,",
+          "Oliver Rhodes"
+        ],
+        "doi": "10.3389/fnins.2018.00816",
+        "year": 2018,
+        "page_count": 20,
+        "reasons": [
+          "author 'kar' in metadata",
+          "year 2018 within \u00b11 of 2019"
+        ]
+      }
+    ],
+    "kubilius2019": [
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\1807.00053v2.pdf",
+        "score": 3.75,
+        "title": "Task-Driven Convolutional Recurrent Models of the",
+        "authors": [
+          "Visual System",
+          "Aran Nayebi1,*, Daniel Bear2,*, Jonas Kubilius5,7,*, Kohitij Kar5, Surya Ganguli4,8, David",
+          "Sussillo8",
+          "James J. DiCarlo5,6",
+          "Daniel L. K. Yamins2,3,9",
+          "6Department of Brain",
+          "Cognitive Sciences",
+          "Cambridge",
+          "MA 02139",
+          "7Brain",
+          "Cognition",
+          "KU Leuven",
+          "Leuven",
+          "Belgium"
+        ],
+        "doi": null,
+        "year": 2018,
+        "page_count": 16,
+        "reasons": [
+          "author 'kubilius' in metadata",
+          "year 2018 within \u00b11 of 2019"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\schrimpf2020_brainscore_biorxiv_v2.pdf",
+        "score": 3.75,
+        "title": "Brain-Score: Which Artificial Neural Network for Object Recognition is most Brain-Like?",
+        "authors": [
+          "Object Recognition is most Brain-Like?",
+          "Martin Schrimpf*,1,2, Jonas Kubilius*,3,4, Ha Hong5, Najib J. Majaj6, Rishi Rajalingham1, Elias B. Issa7, Kohitij Kar1,3,",
+          "Pouya Bashivan1,3, Jonathan Prescott-Roy1, Franziska Geiger3, Kailyn Schmidt1, Daniel L. K. Yamins8,9, James J. DiCarlo1,2,3",
+          "1Department of Brain",
+          "Cognitive Sciences",
+          "Cambridge",
+          "MA 02139",
+          "2Center for Brains",
+          "Minds",
+          "Machines",
+          "Cambridge",
+          "MA 02139",
+          "4Brain",
+          "Cognition",
+          "KU Leuven",
+          "Leuven",
+          "Belgium"
+        ],
+        "doi": "10.1101/407007",
+        "year": 2020,
+        "page_count": 9,
+        "reasons": [
+          "author 'kubilius' in metadata",
+          "year 2020 within \u00b11 of 2019"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\NeurIPS-2019-brain-like-object-recognition-with-high-performing-shallow-recurrent-anns-Paper.pdf",
+        "score": 3.0,
+        "title": "Brain-Like Object Recognition with High-Performing Shallow Recurrent ANNs",
+        "authors": [
+          "Jonas Kubilius*,1,2, Martin Schrimpf *,1,3,4,",
+          "Kohitij Kar1,3,4, Rishi Rajalingham1, Ha Hong5, Najib J. Majaj6, Elias B. Issa7, Pouya",
+          "Daniel L. K. Yamins9,10",
+          "James J. DiCarlo1,3,4",
+          "2Brain",
+          "Cognition",
+          "KU Leuven",
+          "Leuven",
+          "Belgium",
+          "3Department of Brain",
+          "Cognitive Sciences",
+          "Cambridge",
+          "MA 02139",
+          "4Center for Brains",
+          "Minds",
+          "Machines",
+          "Cambridge",
+          "MA 02139"
+        ],
+        "doi": null,
+        "year": null,
+        "page_count": 12,
+        "reasons": [
+          "author 'kubilius' in metadata"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\1911.02385v1.pdf",
+        "score": 2.0,
+        "title": "SpiNNaker 2: A 10 Million Core Processor",
+        "authors": [
+          "System for Brain Simulation",
+          "Machine",
+          "Christian Mayr a,1, Sebastian Hppner a and Steve Furber b",
+          "a Chair of Highly-Parallel VLSI-Systems",
+          "Neuromorphic Circuits",
+          "Institute of Circuits"
+        ],
+        "doi": null,
+        "year": 2019,
+        "page_count": 4,
+        "reasons": [
+          "year 2019 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\Aimone_Severa_Vineyard_2019_ICONS_Fugu.pdf",
+        "score": 2.0,
+        "title": "Composing neural algorithms with Fugu",
+        "authors": [
+          "James B. Aimone*, William Severa, Craig M. Vineyard"
+        ],
+        "doi": "10.1145/nnnnnnn.nnnnnnn",
+        "year": 2019,
+        "page_count": 8,
+        "reasons": [
+          "year 2019 exact match"
+        ]
+      }
+    ],
+    "parisi2019": [
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\1911.02385v1.pdf",
+        "score": 2.0,
+        "title": "SpiNNaker 2: A 10 Million Core Processor",
+        "authors": [
+          "System for Brain Simulation",
+          "Machine",
+          "Christian Mayr a,1, Sebastian Hppner a and Steve Furber b",
+          "a Chair of Highly-Parallel VLSI-Systems",
+          "Neuromorphic Circuits",
+          "Institute of Circuits"
+        ],
+        "doi": null,
+        "year": 2019,
+        "page_count": 4,
+        "reasons": [
+          "year 2019 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\Aimone_Severa_Vineyard_2019_ICONS_Fugu.pdf",
+        "score": 2.0,
+        "title": "Composing neural algorithms with Fugu",
+        "authors": [
+          "James B. Aimone*, William Severa, Craig M. Vineyard"
+        ],
+        "doi": "10.1145/nnnnnnn.nnnnnnn",
+        "year": 2019,
+        "page_count": 8,
+        "reasons": [
+          "year 2019 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\arxiv2019_memory_simulations.pdf",
+        "score": 2.0,
+        "title": "Pre Test Excerpt",
+        "authors": [
+          "Neural-network models of memory consolidation",
+          "reconsolidation",
+          "Peter Helfer (peter.helfer@mail.mcgill.ca)"
+        ],
+        "doi": null,
+        "year": 2019,
+        "page_count": 6,
+        "reasons": [
+          "year 2019 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\brown2019_hot_consciousness.pdf",
+        "score": 2.0,
+        "title": "Understanding the Higher-Order Approach to Consciousness",
+        "authors": [
+          "Richard Brown,1 Hakwan Lau,2,3 and Joseph E. LeDoux4,5,6,*",
+          "by critics. Here",
+          "we clarify its position on several issues",
+          "distinguish it from",
+          "other views",
+          "such as the global workspace theory (GWT)",
+          "early sensory",
+          "position between GWT",
+          "early sensory views. We also clarify that most propo-",
+          "What Is HOT?"
+        ],
+        "doi": "10.1016/j.tics.2019.06.009",
+        "year": 2019,
+        "page_count": 15,
+        "reasons": [
+          "year 2019 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\Research-Papers\\dissertation-ch1-additions\\Diedrichsen_etal_2019_Neuron_cerebellar_function.pdf",
+        "score": 2.0,
+        "title": "Universal Transform or Multiple Functionality? Understanding the Contribution of the Human Cerebellum across Task Domains.",
+        "authors": [
+          "Universal Transform or Multiple Functionality? Understanding",
+          "1.Brain",
+          "Mind Institute",
+          "Western University",
+          "N6A 5B7",
+          "London",
+          "ON N6A5B7",
+          "Canada",
+          "2.Department of Statistical",
+          "Actuarial Sciences",
+          "Western University",
+          "London",
+          "ON N6A5B7,"
+        ],
+        "doi": "10.1016/j.neuron.2019.04.021",
+        "year": 2019,
+        "page_count": 23,
+        "reasons": [
+          "year 2019 exact match"
+        ]
+      }
+    ],
+    "huys2016": [
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\huys2014_mbmf.pdf",
+        "score": 4.0,
+        "title": "Reward-Based Learning, Model-Based and Model-Free",
+        "authors": [
+          "Reward-Based Learning",
+          "Model-Based",
+          "Model-Free",
+          "Quentin J. M. Huysa,b*",
+          "Anthony Cruickshankc",
+          "Peggy Seri\u00e8sc",
+          "aTranslational Neuromodeling Unit",
+          "Institute of Biomedical Engineering",
+          "ETH Z\u20acurich",
+          "University of Z\u20acurich",
+          "Z\u20acurich,",
+          "bDepartment of Psychiatry",
+          "Psychotherapy",
+          "Psychosomatics",
+          "Hospital of Psychiatry",
+          "University of Z\u20acurich",
+          "Z\u20acurich,",
+          "cInstitute of Adaptive",
+          "Neural Computation",
+          "University of Edinburgh",
+          "Edinburgh",
+          "such that actions take into account both immediate",
+          "delayed consequences. They fall into two",
+          "broad classes. Model-based approaches assume an explicit model of the environment",
+          "the agent.",
+          "The model describes the consequences of actions",
+          "the associated returns. From this",
+          "optimal",
+          "explicit knowledge of the dynamics of the environment or the consequences of actions",
+          "evaluate",
+          "Detailed Description"
+        ],
+        "doi": "10.1007/978-1-4614-7320-6_674-1",
+        "year": 2014,
+        "page_count": 10,
+        "reasons": [
+          "author 'huys' in metadata",
+          "author 'huys' in filename"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\From_Human_to_Artificial_Cognition_and_B.pdf",
+        "score": 2.0,
+        "title": "From Human to Artificial Cognition and Back: New Perspectives on Cogni-",
+        "authors": [
+          "Accepted Manuscript",
+          "From Human to Artificial Cognition and Back: New Perspectives on Cogni-",
+          "Antonio Lieto, Daniele P. Radicioni",
+          "Cognitive Systems Research",
+          "Received Date:",
+          "Accepted Date:",
+          "Please cite this article as: Lieto",
+          "Radicioni",
+          "D.P.",
+          "From Human to Artificial Cognition",
+          "Back: New Perspectives"
+        ],
+        "doi": "10.1016/j.cogsys.2016.02.002",
+        "year": 2016,
+        "page_count": 8,
+        "reasons": [
+          "year 2016 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\Grosmark Science 16 main+suppl.pdf",
+        "score": 2.0,
+        "title": "Diversity in neural firing dynamics",
+        "authors": [
+          "supports both rigid",
+          "learned",
+          "Andres D. Grosmark1,2",
+          "Gy\u00f6rgy Buzs\u00e1ki2,3*",
+          "limited change across sleep-experience-sleep",
+          "a slow-firing plastic subset. Slow-firing",
+          "their association with ripples",
+          "showed increased bursting",
+          "temporal coactivation",
+          "during postexperience sleep. Thus",
+          "slow-",
+          "fast-firing neurons",
+          "although forming a",
+          "continuous distribution",
+          "have different coding",
+          "plastic properties."
+        ],
+        "doi": null,
+        "year": 2016,
+        "page_count": 53,
+        "reasons": [
+          "year 2016 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\Learning_task_goals_interactively_with_v.pdf",
+        "score": 2.0,
+        "title": "This space is reserved for the Procedia header, do not use it",
+        "authors": [
+          "Learning Task Goals Interactively with Visual",
+          "James Kirk, Aaron Mininger, and John Laird"
+        ],
+        "doi": null,
+        "year": 2016,
+        "page_count": 14,
+        "reasons": [
+          "year 2016 exact match"
+        ]
+      },
+      {
+        "path": "C:\\Users\\jpcol\\Documents\\Literature-Review\\Literature-Review\\data\\raw\\nihms-470224.pdf",
+        "score": 2.0,
+        "title": "A functional and perceptual signature of the second visual area",
+        "authors": [
+          "A functional",
+          "perceptual signature of the second visual area",
+          "Jeremy Freeman*, Corey M. Ziemba*, David J. Heeger, Eero P. Simoncelli, and J. Anthony",
+          "Center for Neural Science",
+          "Department of Psychology",
+          "Howard Hughes Medical Institute,",
+          "New York University, New York, NY 10003, USA."
+        ],
+        "doi": "10.1038/nn.3402",
+        "year": 2016,
+        "page_count": 31,
+        "reasons": [
+          "year 2016 exact match"
+        ]
+      }
+    ]
+  }
+}

--- a/literature_review/config/model_config.py
+++ b/literature_review/config/model_config.py
@@ -213,52 +213,73 @@ class Models:
         )
     
     @staticmethod
-    def claude_opus() -> ModelConfig:
-        """Claude 3 Opus - Anthropic's most capable."""
+    def claude_opus_4_7() -> ModelConfig:
+        """Claude 4.7 Opus (1M context) - Primary reviewer model."""
         return ModelConfig(
             provider=ModelProvider.ANTHROPIC,
-            model_name="claude-3-opus-20240229",
+            model_name="claude-opus-4-7",
             api_key_env="ANTHROPIC_API_KEY",
-            display_name="Claude 3 Opus",
+            display_name="Claude 4.7 Opus (1M)",
             temperature=0.2,
-            max_tokens=4096,
+            max_tokens=16384,
             input_cost_per_1k=0.015,
             output_cost_per_1k=0.075,
-            supports_json_mode=False,  # Uses XML-like format
-            max_context_length=200000
+            supports_json_mode=False,  # Use prompt-level JSON instruction
+            max_context_length=1_000_000,
+            requests_per_minute=50,
+            fallback_model="gemini-flash-latest",
         )
-    
+
     @staticmethod
-    def claude_sonnet() -> ModelConfig:
-        """Claude 3.5 Sonnet - Balanced performance/cost."""
+    def claude_sonnet_4_6() -> ModelConfig:
+        """Claude 4.6 Sonnet (1M context) - Secondary / lighter-task model."""
         return ModelConfig(
             provider=ModelProvider.ANTHROPIC,
-            model_name="claude-3-5-sonnet-20241022",
+            model_name="claude-sonnet-4-6",
             api_key_env="ANTHROPIC_API_KEY",
-            display_name="Claude 3.5 Sonnet",
+            display_name="Claude 4.6 Sonnet (1M)",
             temperature=0.2,
-            max_tokens=8192,
+            max_tokens=16384,
             input_cost_per_1k=0.003,
             output_cost_per_1k=0.015,
             supports_json_mode=False,
-            max_context_length=200000
+            max_context_length=1_000_000,
+            requests_per_minute=60,
+            fallback_model="gemini-flash-latest",
         )
-    
+
     @staticmethod
-    def claude_haiku() -> ModelConfig:
-        """Claude 3 Haiku - Fast and cheap."""
+    def claude_haiku_4_5() -> ModelConfig:
+        """Claude 4.5 Haiku - Fast and cheap."""
         return ModelConfig(
             provider=ModelProvider.ANTHROPIC,
-            model_name="claude-3-haiku-20240307",
+            model_name="claude-haiku-4-5-20251001",
             api_key_env="ANTHROPIC_API_KEY",
-            display_name="Claude 3 Haiku",
+            display_name="Claude 4.5 Haiku",
             temperature=0.2,
-            max_tokens=4096,
+            max_tokens=8192,
             input_cost_per_1k=0.00025,
             output_cost_per_1k=0.00125,
             supports_json_mode=False,
-            max_context_length=200000
+            max_context_length=200000,
+            fallback_model="gemini-flash-latest",
         )
+
+    # Legacy aliases (kept for backwards compatibility)
+    @staticmethod
+    def claude_opus() -> ModelConfig:
+        """Legacy alias -> Claude 4.7 Opus."""
+        return Models.claude_opus_4_7()
+
+    @staticmethod
+    def claude_sonnet() -> ModelConfig:
+        """Legacy alias -> Claude 4.6 Sonnet."""
+        return Models.claude_sonnet_4_6()
+
+    @staticmethod
+    def claude_haiku() -> ModelConfig:
+        """Legacy alias -> Claude 4.5 Haiku."""
+        return Models.claude_haiku_4_5()
     
     @staticmethod
     def ollama_llama() -> ModelConfig:
@@ -294,13 +315,21 @@ MODEL_REGISTRY: Dict[str, Callable[[], ModelConfig]] = {
     "gpt-4o": Models.gpt4o,
     "gpt-3.5-turbo": Models.gpt35_turbo,
     
-    # Anthropic models
+    # Anthropic models (current generation)
+    "claude-opus-4-7": Models.claude_opus_4_7,
+    "claude-opus-4.7": Models.claude_opus_4_7,
+    "claude-sonnet-4-6": Models.claude_sonnet_4_6,
+    "claude-sonnet-4.6": Models.claude_sonnet_4_6,
+    "claude-haiku-4-5-20251001": Models.claude_haiku_4_5,
+    "claude-haiku-4-5": Models.claude_haiku_4_5,
+
+    # Anthropic legacy aliases (map to current generation)
     "claude-3-opus": Models.claude_opus,
-    "claude-opus": Models.claude_opus,  # Alias
+    "claude-opus": Models.claude_opus,
     "claude-3.5-sonnet": Models.claude_sonnet,
-    "claude-sonnet": Models.claude_sonnet,  # Alias
+    "claude-sonnet": Models.claude_sonnet,
     "claude-3-haiku": Models.claude_haiku,
-    "claude-haiku": Models.claude_haiku,  # Alias
+    "claude-haiku": Models.claude_haiku,
     
     # Local models
     "llama3:8b": Models.ollama_llama,
@@ -346,17 +375,18 @@ def set_model_config(config: ModelConfig) -> None:
 def get_model_config() -> ModelConfig:
     """
     Get the current model configuration.
-    
+
     Resolution order:
     1. Explicitly set model (via set_model)
     2. MODEL_NAME environment variable
-    3. Default (gemini-flash-latest)
+    3. Default: Claude 4.7 Opus when ANTHROPIC_API_KEY is set,
+       otherwise Gemini Flash (fallback for environments without Anthropic creds)
     """
     global _current_model
-    
+
     if _current_model is not None:
         return _current_model
-    
+
     # Check environment variable
     env_model = os.environ.get("MODEL_NAME")
     if env_model:
@@ -366,9 +396,18 @@ def get_model_config() -> ModelConfig:
             return _current_model
         except ValueError as e:
             logger.warning(f"Invalid MODEL_NAME env var: {e}")
-    
-    # Default
-    _current_model = Models.gemini_flash()
+
+    # Default: prefer Claude 4.7 Opus when credentials are available
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        _current_model = Models.claude_opus_4_7()
+        logger.info(f"Default model selected: {_current_model.display_name}")
+    else:
+        _current_model = Models.gemini_flash()
+        logger.info(
+            "ANTHROPIC_API_KEY not set; defaulting to %s. "
+            "Set ANTHROPIC_API_KEY to enable the Claude 4.7 Opus primary path.",
+            _current_model.display_name,
+        )
     return _current_model
 
 

--- a/literature_review/config/model_config.py
+++ b/literature_review/config/model_config.py
@@ -38,6 +38,11 @@ class ModelProvider(Enum):
     GEMINI = "gemini"
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
+    # CLAUDE_CODE routes calls through the `claude-agent-sdk` package using
+    # the user's Claude Code / Max-plan credentials. Unlike ANTHROPIC, this
+    # path does NOT bill per token against an API key — it consumes the
+    # subscription's hourly Code quota instead.
+    CLAUDE_CODE = "claude_code"
     LOCAL = "local"  # Ollama, llama.cpp, etc.
 
 
@@ -81,6 +86,7 @@ class ModelConfig:
     
     # Rate limiting configuration
     requests_per_minute: int = 60
+    requests_per_hour: int = 0  # 0 disables the sliding-window hourly limiter
     tokens_per_minute: int = 100000
     retry_delay_seconds: float = 1.0
     max_retries: int = 3
@@ -265,6 +271,55 @@ class Models:
             fallback_model="gemini-flash-latest",
         )
 
+    # ------------------------------------------------------------------
+    # Claude Code (subscription-backed) path
+    # ------------------------------------------------------------------
+    # These entries route through `claude-agent-sdk` using the user's
+    # local Claude Code credentials (Max / Pro subscription), NOT a
+    # per-token Anthropic API key. The api_key_env is left as the SDK's
+    # own auth marker and is informational only — the SDK reads its
+    # credentials from the user's Claude Code config.
+    #
+    # Default hourly cap is 18 requests; override at runtime with the
+    # CLAUDE_CODE_RPH environment variable. The sliding-window limiter
+    # in `literature_review.utils.hourly_rate_limiter` enforces it.
+
+    @staticmethod
+    def claude_code_opus_4_7() -> ModelConfig:
+        """Claude 4.7 Opus via Claude Code (subscription-backed)."""
+        return ModelConfig(
+            provider=ModelProvider.CLAUDE_CODE,
+            model_name="claude-opus-4-7",  # SDK-facing model name
+            api_key_env="CLAUDE_CODE_AUTH",  # informational; SDK uses its own creds
+            display_name="Claude 4.7 Opus (via Claude Code)",
+            temperature=0.2,
+            max_tokens=16384,
+            input_cost_per_1k=0.0,  # subscription, not per-token
+            output_cost_per_1k=0.0,
+            supports_json_mode=False,  # prompt-instructed JSON
+            max_context_length=1_000_000,
+            requests_per_hour=18,
+            fallback_model="claude-opus-4-7",  # fall back to API path if needed
+        )
+
+    @staticmethod
+    def claude_code_sonnet_4_6() -> ModelConfig:
+        """Claude 4.6 Sonnet via Claude Code (subscription-backed)."""
+        return ModelConfig(
+            provider=ModelProvider.CLAUDE_CODE,
+            model_name="claude-sonnet-4-6",
+            api_key_env="CLAUDE_CODE_AUTH",
+            display_name="Claude 4.6 Sonnet (via Claude Code)",
+            temperature=0.2,
+            max_tokens=16384,
+            input_cost_per_1k=0.0,
+            output_cost_per_1k=0.0,
+            supports_json_mode=False,
+            max_context_length=1_000_000,
+            requests_per_hour=24,
+            fallback_model="claude-sonnet-4-6",
+        )
+
     # Legacy aliases (kept for backwards compatibility)
     @staticmethod
     def claude_opus() -> ModelConfig:
@@ -322,6 +377,12 @@ MODEL_REGISTRY: Dict[str, Callable[[], ModelConfig]] = {
     "claude-sonnet-4.6": Models.claude_sonnet_4_6,
     "claude-haiku-4-5-20251001": Models.claude_haiku_4_5,
     "claude-haiku-4-5": Models.claude_haiku_4_5,
+
+    # Claude Code (subscription-backed) routes — opt-in via MODEL_NAME
+    "claude-code-opus-4-7": Models.claude_code_opus_4_7,
+    "claude-code-opus": Models.claude_code_opus_4_7,
+    "claude-code-sonnet-4-6": Models.claude_code_sonnet_4_6,
+    "claude-code-sonnet": Models.claude_code_sonnet_4_6,
 
     # Anthropic legacy aliases (map to current generation)
     "claude-3-opus": Models.claude_opus,

--- a/literature_review/config/model_config.py
+++ b/literature_review/config/model_config.py
@@ -220,7 +220,13 @@ class Models:
     
     @staticmethod
     def claude_opus_4_7() -> ModelConfig:
-        """Claude 4.7 Opus (1M context) - Primary reviewer model."""
+        """Claude 4.7 Opus (1M context) - Primary reviewer model.
+
+        Extended thinking is enabled per session-call policy
+        (feedback_top_tier_subagents.md, 2026-05-01). The API path uses the
+        native `thinking` parameter; the Claude Code path uses the
+        `ultrathink` prompt keyword. Both are wired in `llm_client.py`.
+        """
         return ModelConfig(
             provider=ModelProvider.ANTHROPIC,
             model_name="claude-opus-4-7",
@@ -231,6 +237,7 @@ class Models:
             input_cost_per_1k=0.015,
             output_cost_per_1k=0.075,
             supports_json_mode=False,  # Use prompt-level JSON instruction
+            supports_thinking_mode=True,  # extended thinking required by policy
             max_context_length=1_000_000,
             requests_per_minute=50,
             fallback_model="gemini-flash-latest",
@@ -249,6 +256,7 @@ class Models:
             input_cost_per_1k=0.003,
             output_cost_per_1k=0.015,
             supports_json_mode=False,
+            supports_thinking_mode=True,  # extended thinking required by policy
             max_context_length=1_000_000,
             requests_per_minute=60,
             fallback_model="gemini-flash-latest",
@@ -286,7 +294,12 @@ class Models:
 
     @staticmethod
     def claude_code_opus_4_7() -> ModelConfig:
-        """Claude 4.7 Opus via Claude Code (subscription-backed)."""
+        """Claude 4.7 Opus via Claude Code (subscription-backed).
+
+        Maximum reasoning is requested via the `ultrathink` prompt keyword
+        in ClaudeCodeClient.generate(); supports_thinking_mode is informational
+        here since the SDK doesn't expose a separate flag.
+        """
         return ModelConfig(
             provider=ModelProvider.CLAUDE_CODE,
             model_name="claude-opus-4-7",  # SDK-facing model name
@@ -297,6 +310,7 @@ class Models:
             input_cost_per_1k=0.0,  # subscription, not per-token
             output_cost_per_1k=0.0,
             supports_json_mode=False,  # prompt-instructed JSON
+            supports_thinking_mode=True,  # delivered via `ultrathink` prompt keyword
             max_context_length=1_000_000,
             requests_per_hour=18,
             fallback_model="claude-opus-4-7",  # fall back to API path if needed
@@ -315,6 +329,7 @@ class Models:
             input_cost_per_1k=0.0,
             output_cost_per_1k=0.0,
             supports_json_mode=False,
+            supports_thinking_mode=True,  # delivered via `ultrathink` prompt keyword
             max_context_length=1_000_000,
             requests_per_hour=24,
             fallback_model="claude-sonnet-4-6",

--- a/literature_review/reviewers/journal_reviewer.py
+++ b/literature_review/reviewers/journal_reviewer.py
@@ -305,6 +305,8 @@ class APIManager:
         from literature_review.config.model_config import (
             ModelProvider,
             get_model_config,
+            get_model_by_name,
+            set_model_config,
         )
 
         self.cache = {}
@@ -321,47 +323,68 @@ class APIManager:
         self.json_generation_config = None
         self.text_generation_config = None
 
-        try:
-            if self.provider == ModelProvider.GEMINI:
-                self._init_gemini_client()
-            else:
-                self._init_llm_client(active_config)
-            logger.info(
-                f"[SUCCESS] API client initialized for {active_config.display_name} "
-                f"(provider: {self.provider.value})"
-            )
-            safe_print(
-                f"✅ API client initialized: {active_config.display_name} "
-                f"({self.provider.value})"
-            )
-        except Exception as e:
-            logger.critical(
-                f"[ERROR] Failed to initialize API client for {active_config.display_name}: {e}"
-            )
-            safe_print(f"❌ Failed to initialize API client: {e}")
-            # If the active provider failed and a fallback is configured, try it.
-            if self.fallback_model_name:
-                logger.warning(
-                    f"Attempting fallback to {self.fallback_model_name} due to init failure"
+        # Walk the configured fallback chain on init failure. Each model
+        # config can declare a `fallback_model` (registry alias); we try
+        # the active model first, then each fallback in turn until one
+        # initialises or we run out (in which case we re-raise).
+        #
+        # Dedup on (provider, model_name) so Claude Code and API paths
+        # for the same underlying model are not considered duplicates.
+
+        def _key(cfg) -> Tuple[str, str]:
+            return (cfg.provider.value, cfg.model_name)
+
+        init_chain = [active_config]
+        seen = {_key(active_config)}
+        cursor = active_config
+        while cursor.fallback_model:
+            try:
+                fb_cfg = get_model_by_name(cursor.fallback_model)
+            except Exception:  # invalid alias — stop walking
+                break
+            if _key(fb_cfg) in seen:
+                break
+            init_chain.append(fb_cfg)
+            seen.add(_key(fb_cfg))
+            cursor = fb_cfg
+
+        last_error: Optional[BaseException] = None
+        last_idx = len(init_chain) - 1
+        for idx, cfg in enumerate(init_chain):
+            is_fallback = idx > 0
+            try:
+                set_model_config(cfg)
+                self.provider = cfg.provider
+                self.active_model_name = cfg.model_name
+                self.fallback_model_name = cfg.fallback_model
+                self._llm_client = None
+                self._gemini_client = None
+                if self.provider == ModelProvider.GEMINI:
+                    self._init_gemini_client()
+                else:
+                    self._init_llm_client(cfg)
+                label = "Fallback" if is_fallback else "API"
+                logger.info(
+                    f"[SUCCESS] {label} client initialized for {cfg.display_name} "
+                    f"(provider: {self.provider.value})"
                 )
-                safe_print(f"⚠️ Falling back to {self.fallback_model_name}")
-                try:
-                    from literature_review.config.model_config import set_model
-                    fb_config = set_model(self.fallback_model_name)
-                    self.provider = fb_config.provider
-                    self.active_model_name = fb_config.model_name
-                    self.fallback_model_name = fb_config.fallback_model
-                    if self.provider == ModelProvider.GEMINI:
-                        self._init_gemini_client()
-                    else:
-                        self._init_llm_client(fb_config)
-                    logger.info(f"[SUCCESS] Fallback client initialized: {fb_config.display_name}")
-                    safe_print(f"✅ Fallback client initialized: {fb_config.display_name}")
-                except Exception as fb_e:
-                    logger.critical(f"[ERROR] Fallback init also failed: {fb_e}")
-                    raise
-            else:
-                raise
+                safe_print(
+                    f"{'⚠️  Falling back to' if is_fallback else '✅ API client initialized:'} "
+                    f"{cfg.display_name} ({self.provider.value})"
+                )
+                break
+            except Exception as e:
+                last_error = e
+                logger.warning(
+                    f"[ATTEMPT FAILED] Could not initialize {cfg.display_name}: {e}"
+                )
+                if not is_fallback:
+                    safe_print(f"❌ Failed to initialize {cfg.display_name}: {e}")
+                if idx == last_idx:
+                    logger.critical(
+                        "[ERROR] No remaining fallbacks; raising last init error"
+                    )
+                    raise last_error from None
 
         try:
             self.embedder = SentenceTransformer('all-MiniLM-L6-v2')

--- a/literature_review/reviewers/journal_reviewer.py
+++ b/literature_review/reviewers/journal_reviewer.py
@@ -401,6 +401,11 @@ class APIManager:
         if not api_key:
             raise ValueError("GEMINI_API_KEY environment variable not set")
         self._gemini_client = genai.Client(api_key=api_key)
+        # NOTE: thinking_budget=0 is intentional for the Gemini path.
+        # The session-call policy (feedback_top_tier_subagents.md /
+        # ../memory/feedback_session_call_policy.md) requires max-effort
+        # reasoning on the primary top-tier model (Claude Opus 4.7). Gemini
+        # Flash is the cheap fallback tier — keep it fast and inexpensive.
         thinking_config = types.ThinkingConfig(thinking_budget=0)
         self.json_generation_config = types.GenerateContentConfig(
             temperature=0.2,

--- a/literature_review/reviewers/journal_reviewer.py
+++ b/literature_review/reviewers/journal_reviewer.py
@@ -13,6 +13,10 @@ import re
 import difflib
 import pypdf
 import pdfplumber
+try:
+    import fitz  # PyMuPDF — primary PDF text + metadata extractor
+except ImportError:  # pragma: no cover
+    fitz = None
 import time
 import concurrent.futures
 import hashlib
@@ -288,41 +292,77 @@ def collect_papers_to_process(folder_path, reviewed_files):
     return files_to_process
 
 
-# --- 1. Initialize APIs and Models (Unchanged) ---
+# --- 1. Initialize APIs and Models ---
 class APIManager:
-    """Manages API calls with rate limiting, caching, and retry logic"""
+    """Manages API calls with rate limiting, caching, and retry logic.
+
+    Provider-aware: the active model (`get_model_config()`) decides which
+    backend to call. Anthropic / OpenAI / local providers go through the
+    `llm_client` abstraction; Gemini retains its direct `genai` path so the
+    `thinking_budget=0` optimisation is preserved.
+    """
     def __init__(self):
+        from literature_review.config.model_config import (
+            ModelProvider,
+            get_model_config,
+        )
+
         self.cache = {}
         self.last_call_time = 0
         self.calls_this_minute = 0
         self.minute_start = time.time()
+
+        active_config = get_model_config()
+        self.provider = active_config.provider
+        self.active_model_name = active_config.model_name
+        self.fallback_model_name = active_config.fallback_model
+        self._llm_client = None  # Lazy-init for non-Gemini providers
+        self._gemini_client = None  # Lazy-init for Gemini provider
+        self.json_generation_config = None
+        self.text_generation_config = None
+
         try:
-            api_key = os.getenv('GEMINI_API_KEY')
-            if not api_key:
-                raise ValueError("GEMINI_API_KEY environment variable not set")
-            self.client = genai.Client(api_key=api_key)
-            thinking_config = types.ThinkingConfig(thinking_budget=0)
-            self.json_generation_config = types.GenerateContentConfig(
-                temperature=0.2,
-                top_p=1.0,
-                top_k=1,
-                max_output_tokens=16384,
-                response_mime_type="application/json",
-                thinking_config=thinking_config
+            if self.provider == ModelProvider.GEMINI:
+                self._init_gemini_client()
+            else:
+                self._init_llm_client(active_config)
+            logger.info(
+                f"[SUCCESS] API client initialized for {active_config.display_name} "
+                f"(provider: {self.provider.value})"
             )
-            self.text_generation_config = types.GenerateContentConfig(
-                temperature=0.2,
-                top_p=1.0,
-                top_k=1,
-                max_output_tokens=16384,
-                thinking_config=thinking_config
+            safe_print(
+                f"✅ API client initialized: {active_config.display_name} "
+                f"({self.provider.value})"
             )
-            logger.info(f"[SUCCESS] Gemini Client (google-ai SDK) initialized (Thinking Disabled).")
-            safe_print(f"✅ Gemini Client initialized successfully (Thinking Disabled).")
         except Exception as e:
-            logger.critical(f"[ERROR] Critical Error initializing Gemini Client: {e}")
-            safe_print(f"❌ Critical Error initializing Gemini Client: {e}")
-            raise
+            logger.critical(
+                f"[ERROR] Failed to initialize API client for {active_config.display_name}: {e}"
+            )
+            safe_print(f"❌ Failed to initialize API client: {e}")
+            # If the active provider failed and a fallback is configured, try it.
+            if self.fallback_model_name:
+                logger.warning(
+                    f"Attempting fallback to {self.fallback_model_name} due to init failure"
+                )
+                safe_print(f"⚠️ Falling back to {self.fallback_model_name}")
+                try:
+                    from literature_review.config.model_config import set_model
+                    fb_config = set_model(self.fallback_model_name)
+                    self.provider = fb_config.provider
+                    self.active_model_name = fb_config.model_name
+                    self.fallback_model_name = fb_config.fallback_model
+                    if self.provider == ModelProvider.GEMINI:
+                        self._init_gemini_client()
+                    else:
+                        self._init_llm_client(fb_config)
+                    logger.info(f"[SUCCESS] Fallback client initialized: {fb_config.display_name}")
+                    safe_print(f"✅ Fallback client initialized: {fb_config.display_name}")
+                except Exception as fb_e:
+                    logger.critical(f"[ERROR] Fallback init also failed: {fb_e}")
+                    raise
+            else:
+                raise
+
         try:
             self.embedder = SentenceTransformer('all-MiniLM-L6-v2')
             logger.info("[SUCCESS] Sentence Transformer initialized.")
@@ -332,6 +372,41 @@ class APIManager:
             safe_print(f"⚠️ Could not initialize Sentence Transformer: {e}")
             self.embedder = None
 
+    def _init_gemini_client(self):
+        """Initialise the Gemini direct path (preserves thinking_budget=0)."""
+        api_key = os.getenv('GEMINI_API_KEY')
+        if not api_key:
+            raise ValueError("GEMINI_API_KEY environment variable not set")
+        self._gemini_client = genai.Client(api_key=api_key)
+        thinking_config = types.ThinkingConfig(thinking_budget=0)
+        self.json_generation_config = types.GenerateContentConfig(
+            temperature=0.2,
+            top_p=1.0,
+            top_k=1,
+            max_output_tokens=16384,
+            response_mime_type="application/json",
+            thinking_config=thinking_config,
+        )
+        self.text_generation_config = types.GenerateContentConfig(
+            temperature=0.2,
+            top_p=1.0,
+            top_k=1,
+            max_output_tokens=16384,
+            thinking_config=thinking_config,
+        )
+
+    def _init_llm_client(self, active_config):
+        """Initialise the unified llm_client for non-Gemini providers."""
+        from literature_review.utils.llm_client import get_llm_client
+        self._llm_client = get_llm_client(active_config)
+
+    # Backwards-compatible attribute access: legacy callers reference
+    # `api_manager.client` expecting the Gemini SDK object. Preserve that
+    # only when Gemini is active; otherwise expose the llm_client.
+    @property
+    def client(self):
+        return self._gemini_client if self._gemini_client is not None else self._llm_client
+
     def rate_limit(self):
         """Implement rate limiting using global limiter"""
         global_limiter.wait_for_quota()
@@ -340,15 +415,29 @@ class APIManager:
     API_REQUEST_TIMEOUT = 600
 
     def _make_api_request(self, prompt: str, is_json: bool) -> str:
-        """Internal method to make API request (used with timeout wrapper)."""
-        model_name = get_model_config().model_name
-        current_config_object = self.json_generation_config if is_json else self.text_generation_config
-        response = self.client.models.generate_content(
-            model=model_name,
-            contents=prompt,
-            config=current_config_object
-        )
-        return response.text
+        """Internal method to make API request (used with timeout wrapper).
+
+        Dispatches by provider: Gemini uses the direct `genai` client (with
+        thinking disabled); all other providers go through `llm_client`.
+        """
+        from literature_review.config.model_config import ModelProvider
+
+        if self.provider == ModelProvider.GEMINI and self._gemini_client is not None:
+            model_name = get_model_config().model_name
+            current_config_object = (
+                self.json_generation_config if is_json else self.text_generation_config
+            )
+            response = self._gemini_client.models.generate_content(
+                model=model_name,
+                contents=prompt,
+                config=current_config_object,
+            )
+            return response.text
+
+        # All other providers (Anthropic, OpenAI, local) via llm_client
+        if self._llm_client is None:
+            raise RuntimeError("No LLM client initialised")
+        return self._llm_client.generate(prompt=prompt, json_mode=is_json)
 
     def cached_api_call(self, prompt: str, use_cache: bool = True, is_json: bool = True) -> Optional[Any]:
         """Make API call with caching, validation, timeout, and retry logic.
@@ -501,6 +590,46 @@ class TextExtractor:
         return is_valid, indicators
 
     @staticmethod
+    def extract_with_pymupdf(filepath: str) -> Tuple[str, float]:
+        """Extract text using PyMuPDF (fitz) — primary extractor.
+
+        PyMuPDF is the dissertation's chosen extraction backend, so we use the
+        same library here to keep filename-to-content mapping consistent.
+        """
+        if fitz is None:
+            logger.warning("PyMuPDF (fitz) not installed; skipping pymupdf extraction")
+            return "", 0.0
+        text = ""
+        quality = 0.0
+        try:
+            doc = fitz.open(filepath)
+        except Exception as e:
+            logger.error(f"pymupdf failed to open {os.path.basename(filepath)}: {e}")
+            return "", 0.0
+        try:
+            page_count = len(doc)
+            if page_count == 0:
+                logger.warning(f"pymupdf found 0 pages in {os.path.basename(filepath)}")
+                return "", 0.0
+            extracted_chars = 0
+            for i, page in enumerate(doc):
+                try:
+                    page_text = page.get_text() or ""
+                    if page_text:
+                        text += page_text + "\n"
+                        extracted_chars += len(page_text)
+                except Exception as page_e:
+                    logger.warning(f"pymupdf error on page {i + 1}: {page_e}")
+            quality = min(extracted_chars / (page_count * 1500.0), 1.0)
+            logger.debug(f"pymupdf extracted ~{len(text)} chars, quality score: {quality:.2f}")
+            return text, quality
+        finally:
+            try:
+                doc.close()
+            except Exception:
+                pass
+
+    @staticmethod
     def extract_with_pypdf(filepath: str) -> Tuple[str, float]:
         """Extract text using pypdf"""
         text = ""
@@ -591,7 +720,15 @@ class TextExtractor:
             text, quality = cls.extract_from_html(filepath)
             method = "html_parser"
         elif file_ext == '.pdf':
-            methods_to_try = [("pdfplumber", cls.extract_with_pdfplumber), ("pypdf", cls.extract_with_pypdf)]
+            # Primary: pymupdf (matches dissertation's extraction backend).
+            # Fallbacks: pdfplumber, pypdf — only consulted if pymupdf yields
+            # less text. Highest-yield extractor wins, but pymupdf is tried first
+            # so its result is the baseline.
+            methods_to_try = [
+                ("pymupdf", cls.extract_with_pymupdf),
+                ("pdfplumber", cls.extract_with_pdfplumber),
+                ("pypdf", cls.extract_with_pypdf),
+            ]
             best_text, best_quality, best_method = "", 0.0, "none"
             for method_name, method_func in methods_to_try:
                 current_text, current_quality = method_func(filepath)
@@ -2000,7 +2137,7 @@ def process_batch(batch_files: List[Tuple[str, str]], api_manager: APIManager,
             papers_root = PAPERS_FOLDER
             rel_path = os.path.relpath(os.path.dirname(filepath), papers_root)
             domain_context = rel_path if rel_path != '.' else 'root'
-            
+
             metadata = PaperMetadata(
                 filename=filename,
                 filepath=filepath,
@@ -2009,6 +2146,22 @@ def process_batch(batch_files: List[Tuple[str, str]], api_manager: APIManager,
                 extraction_method=method,
                 timestamp=datetime.now().isoformat()
             )
+
+            # --- PDF metadata via pymupdf (filename -> paper mapping) ---
+            # Extracts title, authors, DOI, year, and page count using the
+            # same backend the dissertation uses. This metadata is attached
+            # to the review result so review_version_history.json carries a
+            # high-fidelity filename->paper mapping. Note: these summaries
+            # are NOT verbatim excerpts and must not be used for citation
+            # chain verification — that path is the dissertation's own
+            # pymupdf -> citation_log_gate pipeline.
+            pdf_metadata = {}
+            if filepath.lower().endswith('.pdf'):
+                try:
+                    from literature_review.metadata_extractor import EnhancedMetadataExtractor
+                    pdf_metadata = EnhancedMetadataExtractor().extract_metadata(filepath)
+                except Exception as md_e:
+                    logger.warning(f"pymupdf metadata extraction failed for {filename}: {md_e}")
 
             # The validation logic is now simplified. We trust the extraction more.
             if quality > 0.1: # If extraction had some success
@@ -2074,6 +2227,19 @@ def process_batch(batch_files: List[Tuple[str, str]], api_manager: APIManager,
                     result['SIMILAR_PAPERS'] = ["Error"]
                     result['CROSS_REFERENCES_COUNT'] = "-1"
                     result['MENTIONED_PAPERS'] = ["Error"]
+
+                if pdf_metadata:
+                    result['PDF_METADATA'] = {
+                        'filename': filename,
+                        'filepath': filepath,
+                        'title': pdf_metadata.get('title'),
+                        'authors': pdf_metadata.get('authors'),
+                        'doi': pdf_metadata.get('doi'),
+                        'year': pdf_metadata.get('year'),
+                        'page_count': pdf_metadata.get('page_count'),
+                        'extraction_backend': 'pymupdf',
+                        'extraction_confidence': pdf_metadata.get('confidence', {}),
+                    }
 
                 version_control.save_version(filename, result)
                 batch_journal_results.append(result)

--- a/literature_review/utils/hourly_rate_limiter.py
+++ b/literature_review/utils/hourly_rate_limiter.py
@@ -1,0 +1,112 @@
+"""Sliding-window hourly rate limiter for subscription-backed LLM paths.
+
+Used by the Claude Code (`claude-agent-sdk`) provider to stay within
+Max-plan rate budgets while sharing the account with interactive use.
+
+Configuration precedence (highest first):
+  1. Explicit ``limit_per_hour`` argument to ``HourlyRateLimiter``.
+  2. ``CLAUDE_CODE_RPH`` environment variable.
+  3. ``ModelConfig.requests_per_hour`` (set on the model definition).
+  4. Default of 18 requests/hour.
+
+The limiter keeps a deque of call timestamps; ``acquire`` drops anything
+older than 60 minutes, and if the remaining window is at capacity it
+sleeps until the oldest timestamp ages out. Calls are thread-safe.
+
+This is intentionally *continuous* (sliding window) rather than periodic
+(burst then long sleep) so that:
+
+  - Interactive Claude Code use on the same account isn't interrupted by
+    multi-minute idle gaps from the pipeline.
+  - Throughput is predictable: never more than ``limit_per_hour`` calls
+    in any rolling 60-minute window.
+  - Bursting is impossible — the API spec for Max-plan windows is
+    enforced at the application layer here.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections import deque
+from typing import Deque
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_RPH = 18  # comfortable for ~10-18 single-eval papers/hr with margin
+
+
+class HourlyRateLimiter:
+    """Sliding-window per-hour rate limiter.
+
+    Args:
+        limit_per_hour: Maximum calls allowed in any rolling 60-minute
+            window. Pass 0 to disable (the limiter becomes a no-op).
+        name: Human-readable label used in log messages.
+    """
+
+    def __init__(self, limit_per_hour: int | None = None, name: str = "claude_code"):
+        if limit_per_hour is None:
+            env = os.environ.get("CLAUDE_CODE_RPH")
+            try:
+                limit_per_hour = int(env) if env else _DEFAULT_RPH
+            except ValueError:
+                logger.warning(
+                    "Invalid CLAUDE_CODE_RPH=%r; falling back to default %d/hr",
+                    env, _DEFAULT_RPH,
+                )
+                limit_per_hour = _DEFAULT_RPH
+        self.limit = max(0, limit_per_hour)
+        self.name = name
+        self._window: Deque[float] = deque()
+        self._lock = threading.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        return self.limit > 0
+
+    def _prune(self, now: float) -> None:
+        cutoff = now - 3600
+        while self._window and self._window[0] < cutoff:
+            self._window.popleft()
+
+    def remaining(self) -> int:
+        """How many calls are left in the current sliding window."""
+        if not self.enabled:
+            return 2 ** 31
+        with self._lock:
+            self._prune(time.time())
+            return max(0, self.limit - len(self._window))
+
+    def acquire(self) -> float:
+        """Block until a slot is available; return the wait time in seconds.
+
+        Returns 0.0 immediately if the limiter is disabled or the window
+        has capacity.
+        """
+        if not self.enabled:
+            return 0.0
+        total_wait = 0.0
+        while True:
+            with self._lock:
+                now = time.time()
+                self._prune(now)
+                if len(self._window) < self.limit:
+                    self._window.append(now)
+                    return total_wait
+                oldest = self._window[0]
+                # +1s margin so the oldest entry is definitely outside the window
+                wait = max(0.0, 3600 - (now - oldest) + 1.0)
+            logger.info(
+                "[rate_limiter:%s] hourly cap %d/h reached; sleeping %.1fs",
+                self.name, self.limit, wait,
+            )
+            time.sleep(wait)
+            total_wait += wait
+
+    def reset(self) -> None:
+        """Clear the sliding window (useful for tests)."""
+        with self._lock:
+            self._window.clear()

--- a/literature_review/utils/llm_client.py
+++ b/literature_review/utils/llm_client.py
@@ -213,6 +213,133 @@ class AnthropicClient(LLMClient):
         return self._last_usage
 
 
+class ClaudeCodeClient(LLMClient):
+    """Client for Claude routed through Claude Code (subscription-backed).
+
+    Uses the official ``claude-agent-sdk`` Python package. Instead of
+    billing per token against an Anthropic API key, calls consume the
+    user's Claude Code / Max-plan hourly quota.
+
+    Auth: the SDK reads credentials from the same location as the local
+    ``claude`` CLI (typically ``~/.claude/credentials.json``). No API
+    key is passed; ``ANTHROPIC_API_KEY`` is *not* used by this path.
+
+    Rate limits: an ``HourlyRateLimiter`` enforces the configured
+    ``requests_per_hour`` cap (set per ModelConfig, overridable via the
+    ``CLAUDE_CODE_RPH`` env var). The limiter uses a continuous
+    sliding-window strategy so the pipeline interleaves cleanly with
+    any interactive Claude Code use on the same account.
+
+    Concurrency: the SDK is async. The synchronous ``generate`` wraps
+    each query in ``anyio.run`` so callers don't have to refactor.
+    Concurrent calls from multiple threads serialize on the rate
+    limiter; this matches the pipeline's existing sequential batch
+    semantics.
+    """
+
+    def __init__(self, config: ModelConfig):
+        try:
+            from claude_agent_sdk import (  # noqa: F401 — lazy presence check
+                query, ClaudeAgentOptions,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "claude-agent-sdk is required for the CLAUDE_CODE provider. "
+                "Install with: pip install 'claude-agent-sdk>=0.1.0'. "
+                f"Original error: {e}"
+            )
+        # Defer the rate limiter import to avoid a circular dependency
+        from literature_review.utils.hourly_rate_limiter import HourlyRateLimiter
+
+        self.config = config
+        self._last_usage = {"input": 0, "output": 0}
+        # Per-model RPH override falls through to env var, then default
+        rph = config.requests_per_hour or None
+        self._rate_limiter = HourlyRateLimiter(limit_per_hour=rph, name=config.model_name)
+        logger.info(
+            "ClaudeCodeClient ready: model=%s rph_cap=%d remaining=%d",
+            config.model_name, self._rate_limiter.limit, self._rate_limiter.remaining(),
+        )
+
+    def _build_options(self, system_prompt: Optional[str], json_mode: bool):
+        """Construct the ClaudeAgentOptions for a one-shot query."""
+        from claude_agent_sdk import ClaudeAgentOptions  # local import
+
+        # Disable all tools for pipeline use — paper content is arbitrary
+        # text and we don't want the agent reading/writing files or
+        # running bash. Pure text-in / text-out only.
+        kwargs = {
+            "allowed_tools": [],
+            "permission_mode": "bypassPermissions",
+            "max_turns": 1,
+            "model": self.config.model_name,
+        }
+        if system_prompt:
+            # `system_prompt` accepts either a string (treated as additive
+            # instructions) or a SystemPromptPreset. We use the string form.
+            kwargs["system_prompt"] = system_prompt
+        # JSON-mode coaxing happens at the prompt layer (see ``generate``).
+        return ClaudeAgentOptions(**kwargs)
+
+    async def _run_query(self, prompt: str, system_prompt: Optional[str], json_mode: bool) -> str:
+        from claude_agent_sdk import query  # local import
+
+        options = self._build_options(system_prompt, json_mode)
+        text_buf = []
+        async for message in query(prompt=prompt, options=options):
+            # Each message is one of: SystemMessage, AssistantMessage,
+            # UserMessage, ResultMessage. We only care about assistant
+            # text output.
+            content = getattr(message, "content", None)
+            if not content:
+                continue
+            for block in content:
+                block_text = getattr(block, "text", None)
+                if block_text:
+                    text_buf.append(block_text)
+            # ResultMessage carries usage metrics on some SDK versions
+            usage = getattr(message, "usage", None)
+            if usage:
+                self._last_usage = {
+                    "input": getattr(usage, "input_tokens", 0) or 0,
+                    "output": getattr(usage, "output_tokens", 0) or 0,
+                }
+        return "".join(text_buf)
+
+    def generate(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        json_mode: bool = False,
+        **kwargs,
+    ) -> str:
+        import anyio  # required by claude-agent-sdk; safe to import alongside it
+
+        # Coax JSON output at the prompt level — the SDK has no native
+        # JSON-mode equivalent.
+        effective_prompt = prompt
+        if json_mode:
+            effective_prompt = (
+                f"{prompt}\n\n"
+                "Respond with valid JSON only. Do not include any commentary, "
+                "markdown fences, or text outside the JSON object."
+            )
+
+        # Block until the hourly window has capacity.
+        waited = self._rate_limiter.acquire()
+        if waited > 0:
+            logger.info("Claude Code call resumed after %.1fs rate-limit wait", waited)
+
+        return anyio.run(self._run_query, effective_prompt, system_prompt, json_mode)
+
+    def get_token_counts(self) -> Dict[str, int]:
+        return self._last_usage
+
+    def remaining_in_window(self) -> int:
+        """Diagnostic: how many calls left in the current rolling hour."""
+        return self._rate_limiter.remaining()
+
+
 class LocalClient(LLMClient):
     """Client for local models via Ollama."""
     
@@ -296,6 +423,7 @@ def get_llm_client(config: Optional[ModelConfig] = None) -> LLMClient:
         ModelProvider.GEMINI: GeminiClient,
         ModelProvider.OPENAI: OpenAIClient,
         ModelProvider.ANTHROPIC: AnthropicClient,
+        ModelProvider.CLAUDE_CODE: ClaudeCodeClient,
         ModelProvider.LOCAL: LocalClient,
     }
     

--- a/literature_review/utils/llm_client.py
+++ b/literature_review/utils/llm_client.py
@@ -304,22 +304,86 @@ class ClaudeCodeClient(LLMClient):
         )
 
     def _build_options(self, system_prompt: Optional[str], json_mode: bool):
-        """Construct the ClaudeAgentOptions for a one-shot query."""
+        """Construct the ClaudeAgentOptions for a one-shot query.
+
+        Per the session-call policy (Rule 0 — default deny delegation, see
+        ../memory/feedback_session_call_policy.md), the spawned Claude
+        session must itself NOT delegate to further subagents. The
+        reviewer is a leaf-node call: text in, JSON out, no fan-out.
+
+        Defenses in depth (any one of these would block subagent dispatch;
+        we apply all three):
+
+          1. ``allowed_tools=[]`` — empty allowlist; no tools available.
+          2. ``disallowed_tools=[...]`` — explicit deny on the tools that
+             would enable delegation or sandbox escape, even if a future
+             SDK version reinterprets the empty allowlist as "default".
+          3. ``max_turns=1`` — the agent is cut off after a single turn,
+             so even a successful tool call couldn't be followed up on.
+
+        We also disable ``setting_sources`` so this session does not pick
+        up the user's interactive Claude Code config (slash commands,
+        hooks, custom subagents, MCP servers) — those are irrelevant to
+        batch inference and could surprise the spawned session.
+        """
         from claude_agent_sdk import ClaudeAgentOptions  # local import
 
-        # Disable all tools for pipeline use — paper content is arbitrary
-        # text and we don't want the agent reading/writing files or
-        # running bash. Pure text-in / text-out only.
+        # Tools that must NEVER be available in a spawned reviewer session.
+        # "Task" and "Agent" cover the standard delegation surface; the
+        # rest cover sandbox/filesystem/web egress that the reviewer has
+        # no legitimate reason to touch.
+        DELEGATION_AND_EGRESS_TOOLS = [
+            "Task", "Agent",                # subagent dispatch (Rule 0)
+            "Bash", "PowerShell",           # shell execution
+            "Read", "Write", "Edit",        # filesystem
+            "NotebookEdit",
+            "Glob", "Grep",                 # filesystem search
+            "WebFetch", "WebSearch",        # network egress
+        ]
+
         kwargs = {
             "allowed_tools": [],
+            "disallowed_tools": DELEGATION_AND_EGRESS_TOOLS,
             "permission_mode": "bypassPermissions",
             "max_turns": 1,
             "model": self.config.model_name,
+            # Don't inherit user-level Claude Code settings (slash commands,
+            # MCP servers, hooks, custom subagents). The spawned session
+            # should be a clean room.
+            "setting_sources": [],
         }
         if system_prompt:
             # `system_prompt` accepts either a string (treated as additive
             # instructions) or a SystemPromptPreset. We use the string form.
             kwargs["system_prompt"] = system_prompt
+
+        # Filter kwargs to what the installed SDK actually accepts. Older
+        # SDK versions may lack `disallowed_tools` or `setting_sources`;
+        # we still apply the core defense (`allowed_tools=[]` +
+        # `max_turns=1`) but warn so the operator knows the spawned
+        # session is operating with weaker isolation than the policy
+        # specifies. Never silently degrade safety.
+        import dataclasses as _dc
+        try:
+            supported = {f.name for f in _dc.fields(ClaudeAgentOptions)}
+        except TypeError:
+            # ClaudeAgentOptions isn't a dataclass on this SDK version.
+            # Fall through and let the construction raise if any kwarg
+            # is rejected — at least we'll get a clear TypeError.
+            supported = set(kwargs)
+        dropped = set(kwargs) - supported
+        if dropped:
+            critical_drops = dropped & {"disallowed_tools", "setting_sources"}
+            if critical_drops:
+                logger.warning(
+                    "ClaudeAgentOptions on installed claude-agent-sdk lacks "
+                    "kwargs %s. Spawned session will still have allowed_tools=[] "
+                    "and max_turns=1, so subagent dispatch is blocked, but "
+                    "consider upgrading: pip install -U claude-agent-sdk",
+                    sorted(critical_drops),
+                )
+            kwargs = {k: v for k, v in kwargs.items() if k in supported}
+
         # JSON-mode coaxing happens at the prompt layer (see ``generate``).
         return ClaudeAgentOptions(**kwargs)
 

--- a/literature_review/utils/llm_client.py
+++ b/literature_review/utils/llm_client.py
@@ -57,8 +57,16 @@ class GeminiClient(LLMClient):
         
         self.client = genai.Client(api_key=api_key)
         self._last_usage = {"input": 0, "output": 0}
-        
-        # Configure generation settings
+
+        # NOTE on thinking_budget=0:
+        # The session-call policy (feedback_top_tier_subagents.md) requires
+        # maximum-reasoning effort on the *primary* top-tier model (Opus 4.7).
+        # Gemini Flash is intentionally the cheap fallback tier — it only
+        # runs when Claude Code + Anthropic API are both unavailable. We
+        # deliberately keep thinking disabled here to preserve Flash's role
+        # as a fast, low-cost safety net rather than turning it into another
+        # high-effort path. If you want Gemini Pro with thinking enabled,
+        # switch via MODEL_NAME=gemini-pro and update gemini_pro() config.
         thinking_config = types.ThinkingConfig(thinking_budget=0)
         self.json_config = types.GenerateContentConfig(
             temperature=config.temperature,
@@ -190,25 +198,59 @@ class AnthropicClient(LLMClient):
         json_mode: bool = False,
         **kwargs
     ) -> str:
+        # Per session-call policy (feedback_top_tier_subagents.md, 2026-05-01):
+        # every Opus 4.7 dispatch MUST prepend the literal word `ultrathink`
+        # as the first line of the prompt. The Claude Code keyword maps to
+        # the API's extended-thinking feature, which we enable below for
+        # any model whose config declares supports_thinking_mode=True.
+        # See: ../memory/feedback_session_call_policy.md
+        user_message = f"ultrathink\n\n{prompt}"
+
         # Claude doesn't have native JSON mode; add instruction
         if json_mode:
-            prompt = f"{prompt}\n\nRespond with valid JSON only."
-        
-        response = self.client.messages.create(
-            model=self.config.model_name,
-            max_tokens=self.config.max_tokens,
-            system=system_prompt or "",
-            messages=[{"role": "user", "content": prompt}]
-        )
-        
+            user_message = f"{user_message}\n\nRespond with valid JSON only."
+
+        create_kwargs: Dict[str, Any] = {
+            "model": self.config.model_name,
+            "max_tokens": self.config.max_tokens,
+            "system": system_prompt or "",
+            "messages": [{"role": "user", "content": user_message}],
+        }
+
+        if getattr(self.config, "supports_thinking_mode", False):
+            # Anthropic extended-thinking contract:
+            #   - budget_tokens must be < max_tokens
+            #   - temperature must be 1.0 when thinking is enabled
+            # We allocate up to half of max_tokens to the thinking budget,
+            # capped at 8192 to leave generous room for the visible response.
+            budget = max(1024, min(8192, self.config.max_tokens // 2))
+            create_kwargs["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": budget,
+            }
+            create_kwargs["temperature"] = 1.0  # required when thinking is on
+        else:
+            create_kwargs["temperature"] = self.config.temperature
+
+        response = self.client.messages.create(**create_kwargs)
+
         # Track usage
         self._last_usage = {
             "input": response.usage.input_tokens,
             "output": response.usage.output_tokens
         }
-        
+
+        # When thinking is enabled, the response contains both thinking and
+        # text blocks. We only return the visible-text portion to callers
+        # (the JSON parser, etc.) — thinking content is internal.
+        for block in response.content:
+            block_type = getattr(block, "type", None)
+            if block_type == "text" or hasattr(block, "text"):
+                if hasattr(block, "text"):
+                    return block.text
+        # Fallback: legacy shape with a single content[0]
         return response.content[0].text
-    
+
     def get_token_counts(self) -> Dict[str, int]:
         return self._last_usage
 
@@ -315,12 +357,19 @@ class ClaudeCodeClient(LLMClient):
     ) -> str:
         import anyio  # required by claude-agent-sdk; safe to import alongside it
 
+        # Per session-call policy (feedback_top_tier_subagents.md, 2026-05-01):
+        # every Opus 4.7 dispatch MUST prepend the literal word `ultrathink`
+        # as the first line of the prompt. This is the Claude Code operator
+        # keyword for maximum thinking-budget allocation; without it we ship
+        # the model at default reasoning, which violates the policy.
+        # See: ../memory/feedback_session_call_policy.md
+        effective_prompt = f"ultrathink\n\n{prompt}"
+
         # Coax JSON output at the prompt level — the SDK has no native
         # JSON-mode equivalent.
-        effective_prompt = prompt
         if json_mode:
             effective_prompt = (
-                f"{prompt}\n\n"
+                f"{effective_prompt}\n\n"
                 "Respond with valid JSON only. Do not include any commentary, "
                 "markdown fences, or text outside the JSON object."
             )

--- a/literature_review/utils/model_fallback.py
+++ b/literature_review/utils/model_fallback.py
@@ -19,7 +19,12 @@ logger = logging.getLogger(__name__)
 
 # Default fallback chains per provider
 DEFAULT_FALLBACK_CHAINS = {
-    # Primary reviewer: Claude 4.7 Opus -> Claude 4.6 Sonnet -> Gemini Flash
+    # Claude Code (subscription-backed) -> API path -> Gemini Flash.
+    # If the hourly Max-plan quota is exhausted or the SDK errors, the
+    # pipeline falls through to per-token API calls.
+    "claude-code-opus-4-7": ["claude-opus-4-7", "gemini-flash-latest"],
+    "claude-code-sonnet-4-6": ["claude-sonnet-4-6", "gemini-flash-latest"],
+    # Primary reviewer (API): Claude 4.7 Opus -> Claude 4.6 Sonnet -> Gemini Flash
     "claude-opus-4-7": ["claude-sonnet-4-6", "gemini-flash-latest"],
     "claude-sonnet-4-6": ["claude-opus-4-7", "gemini-flash-latest"],
     "gemini-flash-latest": ["gemini-1.5-pro", "claude-sonnet-4-6"],

--- a/literature_review/utils/model_fallback.py
+++ b/literature_review/utils/model_fallback.py
@@ -19,10 +19,14 @@ logger = logging.getLogger(__name__)
 
 # Default fallback chains per provider
 DEFAULT_FALLBACK_CHAINS = {
+    # Primary reviewer: Claude 4.7 Opus -> Claude 4.6 Sonnet -> Gemini Flash
+    "claude-opus-4-7": ["claude-sonnet-4-6", "gemini-flash-latest"],
+    "claude-sonnet-4-6": ["claude-opus-4-7", "gemini-flash-latest"],
+    "gemini-flash-latest": ["gemini-1.5-pro", "claude-sonnet-4-6"],
     "gemini-2.5-flash": ["gemini-1.5-pro", "gpt-4-turbo"],
     "gpt-4-turbo": ["gpt-4o", "gemini-2.5-flash"],
     "gpt-4o": ["gpt-4-turbo", "gemini-2.5-flash"],
-    "claude-3.5-sonnet": ["claude-3-opus", "gpt-4-turbo"],
+    "claude-3.5-sonnet": ["claude-sonnet-4-6", "gpt-4-turbo"],
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ numpy>=1.24.0
 google-generativeai>=0.3.0
 google-genai>=0.1.0
 anthropic>=0.40.0  # Claude 4.7 Opus / 4.6 Sonnet primary path
+claude-agent-sdk>=0.1.0  # Optional: subscription-backed Claude Code routing (MODEL_NAME=claude-code-opus-4-7)
 python-dotenv>=1.0.0
 pyyaml>=6.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pandas>=2.0.0
 numpy>=1.24.0
 google-generativeai>=0.3.0
 google-genai>=0.1.0
+anthropic>=0.40.0  # Claude 4.7 Opus / 4.6 Sonnet primary path
 python-dotenv>=1.0.0
 pyyaml>=6.0.0
 

--- a/scripts/reconcile_dissertation_pdfs.py
+++ b/scripts/reconcile_dissertation_pdfs.py
@@ -1,0 +1,226 @@
+"""Reconcile dissertation citation keys against PDFs in the data directories.
+
+For each citation key in MISSING_KEYS, scan the configured PDF roots, run
+pymupdf metadata extraction, score every PDF against the key, and emit the
+best candidates to dissertation_pdf_mapping.json.
+
+Scope constraints (do not violate):
+  - This script produces a filename -> paper mapping ONLY.
+  - It must NOT bridge review_version_history.json excerpts to the
+    dissertation's citation log. The dissertation's own pymupdf ->
+    citation_log_gate pipeline is the sole verbatim chain.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# Make repo root importable when run from scripts/
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# 8 missing dissertation citation keys (author lastname + year)
+MISSING_KEYS: Dict[str, Dict[str, object]] = {
+    "debole2025":        {"authors": ["debole", "de bole"],         "year": 2025},
+    "khalighrazavi2014": {"authors": ["khaligh-razavi", "khaligh razavi", "khalighrazavi"], "year": 2014},
+    "appuswamy2024":     {"authors": ["appuswamy"],                  "year": 2024},
+    "friston2005":       {"authors": ["friston"],                    "year": 2005},
+    "kar2019":           {"authors": ["kar"],                        "year": 2019},
+    "kubilius2019":      {"authors": ["kubilius"],                   "year": 2019},
+    "parisi2019":        {"authors": ["parisi"],                     "year": 2019},
+    "huys2016":          {"authors": ["huys"],                       "year": 2016},
+}
+
+
+@dataclass
+class Candidate:
+    path: str
+    score: float
+    title: str = ""
+    authors: List[str] = field(default_factory=list)
+    doi: Optional[str] = None
+    year: Optional[int] = None
+    page_count: int = 0
+    reasons: List[str] = field(default_factory=list)
+
+
+def normalise(text: str) -> str:
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9 ]+", " ", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def score_candidate(
+    key: str,
+    spec: Dict[str, object],
+    metadata: Dict,
+    filename: str,
+) -> Tuple[float, List[str]]:
+    """Score how well a PDF's metadata matches a citation key.
+
+    Heuristics (additive):
+      - authors substring match: +3.0 each
+      - year exact match:        +2.0
+      - year within ±1:          +0.75
+      - filename substring of key author + year: +1.5
+      - title contains "year" string: +0.25
+    """
+    score = 0.0
+    reasons: List[str] = []
+
+    md_authors = [normalise(a) for a in metadata.get("authors", []) if a]
+    md_title = normalise(metadata.get("title", "") or "")
+    md_year = metadata.get("year")
+    fname_norm = normalise(filename)
+
+    for author_variant in spec["authors"]:  # type: ignore[index]
+        a_norm = normalise(author_variant)
+        if any(a_norm in a for a in md_authors):
+            score += 3.0
+            reasons.append(f"author '{author_variant}' in metadata")
+        elif a_norm in md_title:
+            score += 1.5
+            reasons.append(f"author '{author_variant}' in title")
+        if a_norm in fname_norm:
+            score += 1.0
+            reasons.append(f"author '{author_variant}' in filename")
+
+    target_year = spec["year"]  # type: ignore[index]
+    if md_year is not None and isinstance(target_year, int):
+        if md_year == target_year:
+            score += 2.0
+            reasons.append(f"year {md_year} exact match")
+        elif abs(md_year - target_year) == 1:
+            score += 0.75
+            reasons.append(f"year {md_year} within ±1 of {target_year}")
+
+    # Filename hint: author+year together
+    for author_variant in spec["authors"]:  # type: ignore[index]
+        token = f"{normalise(author_variant)}{spec['year']}"  # type: ignore[index]
+        if token.replace(" ", "") in fname_norm.replace(" ", ""):
+            score += 1.5
+            reasons.append(f"filename contains '{author_variant}{spec['year']}'")
+            break
+
+    return score, reasons
+
+
+def scan(roots: List[Path], top_n: int = 5, key_filter: Optional[str] = None) -> Dict:
+    try:
+        from literature_review.metadata_extractor import EnhancedMetadataExtractor
+    except ImportError:
+        print("ERROR: cannot import literature_review.metadata_extractor", file=sys.stderr)
+        raise
+
+    md_extractor = EnhancedMetadataExtractor()
+
+    pdfs: List[Path] = []
+    for root in roots:
+        if not root.exists():
+            print(f"WARNING: scan root does not exist: {root}", file=sys.stderr)
+            continue
+        pdfs.extend(root.rglob("*.pdf"))
+        pdfs.extend(root.rglob("*.PDF"))
+    pdfs = sorted(set(pdfs))
+    print(f"Scanning {len(pdfs)} PDFs across {len(roots)} roots", file=sys.stderr)
+
+    keys_to_match = {key_filter: MISSING_KEYS[key_filter]} if key_filter else MISSING_KEYS
+    matches: Dict[str, List[Candidate]] = {k: [] for k in keys_to_match}
+
+    for i, pdf in enumerate(pdfs, 1):
+        if i % 100 == 0:
+            print(f"  [{i}/{len(pdfs)}] scanning...", file=sys.stderr)
+        try:
+            md = md_extractor.extract_metadata(str(pdf))
+        except Exception as e:
+            print(f"  metadata extract failed for {pdf.name}: {e}", file=sys.stderr)
+            continue
+
+        for key, spec in keys_to_match.items():
+            score, reasons = score_candidate(key, spec, md, pdf.name)
+            if score >= 2.0:  # threshold to consider as candidate
+                matches[key].append(
+                    Candidate(
+                        path=str(pdf),
+                        score=score,
+                        title=md.get("title", "") or "",
+                        authors=md.get("authors", []) or [],
+                        doi=md.get("doi"),
+                        year=md.get("year"),
+                        page_count=md.get("page_count", 0) or 0,
+                        reasons=reasons,
+                    )
+                )
+
+    # Sort and truncate
+    out: Dict[str, object] = {
+        "_scope_note": (
+            "filename -> paper mapping only. NOT a verbatim/citation-chain source. "
+            "Dissertation citation log verification is owned by the dissertation's "
+            "own pymupdf -> citation_log_gate pipeline."
+        ),
+        "scan_roots": [str(r) for r in roots],
+        "total_pdfs_scanned": len(pdfs),
+        "candidates": {},
+    }
+    for key, cands in matches.items():
+        cands.sort(key=lambda c: c.score, reverse=True)
+        out["candidates"][key] = [asdict(c) for c in cands[:top_n]]
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-root",
+        action="append",
+        default=None,
+        help="PDF scan root (can repeat). Defaults to main-clone data/raw and worktree data/raw.",
+    )
+    parser.add_argument("--top-n", type=int, default=5, help="Top candidates per key")
+    parser.add_argument("--key", default=None, help="Limit to a single citation key")
+    parser.add_argument(
+        "--output",
+        default="dissertation_pdf_mapping.json",
+        help="Output JSON path",
+    )
+    args = parser.parse_args()
+
+    if args.data_root:
+        roots = [Path(r) for r in args.data_root]
+    else:
+        roots = [
+            Path("data/raw"),
+            Path("data/processed"),
+            Path("C:/Users/jpcol/Documents/Literature-Review/Literature-Review/data/raw"),
+            Path("C:/Users/jpcol/Documents/Literature-Review/Literature-Review/data/processed"),
+        ]
+
+    mapping = scan(roots, top_n=args.top_n, key_filter=args.key)
+    Path(args.output).write_text(json.dumps(mapping, indent=2, default=str), encoding="utf-8")
+    print(f"Wrote mapping to {args.output}")
+
+    # Console summary
+    for key, cands in mapping["candidates"].items():
+        if not cands:
+            print(f"  [{key}] NO CANDIDATES (score >= 2.0)")
+        else:
+            top = cands[0]
+            print(
+                f"  [{key}] best: score={top['score']:.1f}  "
+                f"year={top['year']}  pages={top['page_count']}"
+            )
+            print(f"    path:   {top['path']}")
+            print(f"    title:  {(top['title'] or '')[:80]}")
+            print(f"    doi:    {top['doi']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke_test_reviewer.py
+++ b/scripts/smoke_test_reviewer.py
@@ -1,0 +1,101 @@
+"""Smoke-test the journal-reviewer pipeline on a small batch of PDFs.
+
+Validates the upgraded reviewer end-to-end:
+  - pymupdf-primary PDF text extraction
+  - PDF_METADATA injection (filename/title/authors/DOI/year/page_count)
+  - Provider-aware APIManager (Gemini direct path vs. llm_client)
+  - review_version_history.json receives new entries
+
+Usage:
+    PYTHONIOENCODING=utf-8 python scripts/smoke_test_reviewer.py
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Make repo root importable when run from scripts/
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+# Load env from main clone if worktree has none
+worktree_env = Path(".env")
+if not worktree_env.exists():
+    load_dotenv("C:/Users/jpcol/Documents/Literature-Review/Literature-Review/.env")
+else:
+    load_dotenv(worktree_env)
+
+# Use an isolated version history to avoid stomping on real data
+sandbox_dir = Path(tempfile.mkdtemp(prefix="reviewer_smoke_"))
+sandbox_history = sandbox_dir / "review_version_history.json"
+print(f"Sandbox version history: {sandbox_history}")
+
+# Patch journal_reviewer's VERSION_HISTORY_FILE before import
+import literature_review.reviewers.journal_reviewer as jr  # noqa: E402
+
+jr.VERSION_HISTORY_FILE = str(sandbox_history)
+
+from literature_review.reviewers.journal_reviewer import (  # noqa: E402
+    APIManager,
+    NetworkAnalyzer,
+    ReviewVersionControl,
+    process_batch,
+)
+
+pdfs = glob.glob("data/raw/**/*.pdf", recursive=True)
+print(f"Worktree PDFs: {len(pdfs)}")
+batch_files = [(p, os.path.basename(p)) for p in pdfs[:3]]
+print(f"Smoke batch (3 PDFs):")
+for _, name in batch_files:
+    print(f"  - {name}")
+
+# Minimal pillar definitions
+pillar_definitions_str = json.dumps(
+    {"Pillar1": {"sub_requirements": ["test"], "description": "smoke-test pillar"}}
+)
+
+api_manager = APIManager()
+print(f"APIManager provider: {api_manager.provider.value}")
+print(f"APIManager model: {api_manager.active_model_name}")
+
+network_analyzer = NetworkAnalyzer(api_manager.embedder)
+version_control = ReviewVersionControl()
+
+journal_results, non_journal_results = process_batch(
+    batch_files=batch_files,
+    api_manager=api_manager,
+    network_analyzer=network_analyzer,
+    version_control=version_control,
+    existing_reviews=[],
+    pillar_definitions_str=pillar_definitions_str,
+)
+
+print(f"\nJournal results: {len(journal_results)}")
+print(f"Non-journal results: {len(non_journal_results)}")
+
+# Validate version history
+if sandbox_history.exists():
+    history = json.loads(sandbox_history.read_text(encoding="utf-8"))
+    print(f"\nVersion history entries: {len(history)}")
+    for filename, versions in history.items():
+        latest = versions[-1]["review"]
+        pdf_md = latest.get("PDF_METADATA", {})
+        print(f"\n  {filename}")
+        print(f"    PDF_METADATA present: {bool(pdf_md)}")
+        if pdf_md:
+            print(f"      title:      {(pdf_md.get('title') or '')[:80]}")
+            print(f"      authors:    {pdf_md.get('authors')[:2] if pdf_md.get('authors') else None}")
+            print(f"      doi:        {pdf_md.get('doi')}")
+            print(f"      year:       {pdf_md.get('year')}")
+            print(f"      page_count: {pdf_md.get('page_count')}")
+            print(f"      backend:    {pdf_md.get('extraction_backend')}")
+else:
+    print(f"\nWARNING: version history not created at {sandbox_history}")
+    sys.exit(2)
+
+print("\nSMOKE_TEST_DONE")


### PR DESCRIPTION
## Summary

Two-part upgrade to the literature-review pipeline.

**Part 1 — Models & extraction** (commit 65308de):
- Brings the reviewer onto Claude 4.7 Opus
- Makes pymupdf the primary PDF extractor
- Attaches pymupdf-derived metadata to every review entry (filename to paper mapping)

**Part 2 — Subscription-backed Claude Code routing** (commit 8ed484a):
- Adds an opt-in path that runs Claude calls through `claude-agent-sdk` using your Max-plan credentials instead of a per-token API key
- Sliding-window hourly rate limiter respects Max plan windows
- Falls back to API and Gemini if subscription quota / SDK / key is unavailable

---

## Part 1 — Models & extraction

### What changed

**Model registry** (`literature_review/config/model_config.py`)
- New entries: `claude-opus-4-7` and `claude-sonnet-4-6`, both with `max_context_length=1_000_000` and `fallback_model=gemini-flash-latest`.
- Default model resolution now prefers Claude 4.7 Opus when `ANTHROPIC_API_KEY` is set; otherwise falls back to Gemini Flash. Legacy `claude-3-opus` / `claude-3.5-sonnet` aliases still resolve, now pointing at the 4.x configs.

**Provider-aware reviewer** (`literature_review/reviewers/journal_reviewer.py`)
- `APIManager.__init__` reads the active `ModelConfig` and dispatches by provider: Gemini keeps the direct `genai.Client` path with `thinking_budget=0`; Anthropic / OpenAI / local providers go through the existing `llm_client.get_llm_client()` abstraction.
- `APIManager` walks the full fallback chain on init failure (was single-level). Dedup keyed on `(provider, model_name)` so Claude Code and Anthropic API paths for the same model are tried separately.
- `_make_api_request` routes JSON / text generation accordingly.

**PDF text extraction**
- Added `TextExtractor.extract_with_pymupdf` (uses `fitz`).
- `methods_to_try` now lists pymupdf *first*, followed by pdfplumber and pypdf. The existing best-yielding-extractor-wins logic is unchanged, so quality never regresses.

**PDF metadata injection**
- `process_batch` now calls `EnhancedMetadataExtractor` (pymupdf-backed) on every PDF and attaches a `PDF_METADATA` block (filename, title, authors, DOI, year, page_count, backend, confidence) to each review result. The block lands in `review_version_history.json` via `ReviewVersionControl.save_version`.

**Fallback chains** (`literature_review/utils/model_fallback.py`)
- Added chains for `claude-code-opus-4-7`, `claude-code-sonnet-4-6`, `claude-opus-4-7`, `claude-sonnet-4-6`, and `gemini-flash-latest`.

---

## Part 2 — Claude Code SDK routing (opt-in)

### Motivation

The Anthropic API bills per token; Max-plan Claude Code usage doesn't. This adds a path that runs the reviewer's prompts through your Max-plan quota instead of incurring per-token API charges. Subscription quota, no per-call billing.

### What changed

**New provider** (`literature_review/config/model_config.py`)
- Added `ModelProvider.CLAUDE_CODE` and `requests_per_hour` field on `ModelConfig`.
- New registry entries `claude-code-opus-4-7` (RPH cap 18) and `claude-code-sonnet-4-6` (RPH cap 24).
- Both declare `fallback_model="claude-opus-4-7"` / `claude-sonnet-4-6` so the pipeline falls through to the per-token API path if the SDK / quota is unavailable.

**New client** (`literature_review/utils/llm_client.py`)
- `ClaudeCodeClient(LLMClient)` wraps `claude-agent-sdk.query()` in a sync facade via `anyio.run()`.
- Tools are disabled (`allowed_tools=[]`, `permission_mode="bypassPermissions"`) — pure text-in / text-out for unattended batch use.
- JSON-mode is prompt-instructed since the SDK has no native JSON mode equivalent.
- Lazy-imports the SDK with a clear install hint so users without it get an actionable error, not a stack trace.

**New rate limiter** (`literature_review/utils/hourly_rate_limiter.py`)
- `HourlyRateLimiter` enforces a sliding-window per-hour cap. Continuous strategy (not periodic burst+sleep) so the pipeline interleaves cleanly with interactive Claude Code use on the same account.
- Config precedence: explicit arg → `CLAUDE_CODE_RPH` env var → `ModelConfig.requests_per_hour` → default `18`.
- `acquire()` blocks until the rolling 60-minute window has capacity; `remaining()` exposes current headroom for diagnostics.

**Dependencies** (`requirements.txt`)
- Added `anthropic>=0.40.0` (Part 1).
- Added `claude-agent-sdk>=0.1.0` (Part 2). Optional — only required if you opt into `MODEL_NAME=claude-code-opus-4-7`.

### Selection mode

Purely opt-in. The default model resolution is **unchanged**:
- No env vars set → Gemini Flash
- `ANTHROPIC_API_KEY` set → Claude 4.7 Opus (API path, per-token)
- `MODEL_NAME=claude-code-opus-4-7` set → Claude 4.7 Opus (Claude Code path, subscription-backed)

Run mode is fully under your control via `MODEL_NAME` / `--model`.

### Pacing decision

Continuous sliding-window (not periodic pause-and-resume) for these reasons:
- Plays nicely if you're using Claude Code interactively on the same account — calls are spaced out instead of going dark for an hour
- Predictable cap: never more than N calls in any rolling 60-minute window
- ~30 lines, no scheduling complexity

Default 18 calls/hour comfortably supports ~15-18 single-eval papers/hour or ~6 consensus-eval papers/hour, with headroom for interactive use. Bump it via `CLAUDE_CODE_RPH=30` if you want.

### TOS caveat

Programmatic use of a Max-plan Claude Code session for batch inference is in a grey area at full-corpus scale. Dissertation-scoped runs (10s to low 100s of papers) are almost certainly fine; running 24/7 nightly cron against the full 900-paper corpus would be worth reviewing against the Anthropic AUP first.

---

## Validation runs

- **Smoke test (Part 1)** (`scripts/smoke_test_reviewer.py`): ran the upgraded reviewer against 3 worktree PDFs into a sandbox version history. 2 / 3 analyzed successfully end-to-end; the 3rd hit a pre-existing `'list' object has no attribute 'setdefault'` in `consensus_evaluation` (unrelated). Both successful entries contain `PDF_METADATA` with title / authors / DOI / year / page_count and `extraction_backend: pymupdf`.
- **Incremental dry-run**: `pipeline_orchestrator.py --incremental --dry-run --batch-mode --model gemini-flash-latest` validated cleanly.
- **Reconciliation** (`scripts/reconcile_dissertation_pdfs.py`): 1253 PDFs scanned. Output at `dissertation_pdf_mapping.json`. High-confidence matches: `kar2019` and `kubilius2019`. The remaining 6 keys returned year-level matches only.
- **Rate limiter unit test**: limit honored, env override applied, `limit=0` disables to no-op, sliding-window pruning correct.
- **Mock-SDK test of ClaudeCodeClient**: instantiation, rate-limiter decrement (18 to 17 after one call), json-mode prompt injection, ResultMessage usage parsing all verified.
- **Chain walk**: with neither `claude-agent-sdk` nor `anthropic` installed and no API key, `MODEL_NAME=claude-code-opus-4-7` falls through `Claude Code -> API Opus -> Gemini Flash` cleanly.
- **Default regression**: with no env vars, default is still `gemini-flash-latest`; with `ANTHROPIC_API_KEY`, default is `claude-opus-4-7` (API). Claude Code is never the implicit default.

## Scope guardrails

- `PDF_METADATA` and `dissertation_pdf_mapping.json` are **filename to paper mappings only**. They are *not* a verbatim or citation-chain source. The dissertation's own `pymupdf -> citation_log_gate` pipeline remains the sole path to verified excerpts — this PR does not bridge to it.
- Claude Code path is opt-in. The default behavior is unchanged.

## Test plan

- [ ] `pip install -r requirements.txt` to pick up `anthropic` (and optionally `claude-agent-sdk`)
- [ ] `ANTHROPIC_API_KEY=... pipeline_orchestrator.py --incremental --dry-run --batch-mode` reports `Using model: Claude 4.7 Opus (1M)`
- [ ] With key unset, same command falls back to Gemini Flash
- [ ] Inspect a fresh `review_version_history.json` entry — confirm `PDF_METADATA` block is present
- [ ] After installing `claude-agent-sdk` and ensuring `claude` CLI is authenticated, `MODEL_NAME=claude-code-opus-4-7 pipeline_orchestrator.py --incremental --dry-run --batch-mode` reports `Using model: Claude 4.7 Opus (via Claude Code)`
- [ ] Tune `CLAUDE_CODE_RPH` if 18/hr default needs adjusting
- [ ] Investigate the pre-existing `'list' object has no attribute 'setdefault'` in `consensus_evaluation` (separate from this PR)
- [ ] Decide whether the 6 unmatched dissertation citation keys need to be sourced into `data/raw/`

Generated with Claude Code
