### PR TITLE
chore: pin .claude/settings.json model+effort floor (TC-CC624)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,4 @@
+{
+  "model": "opus",
+  "effortLevel": "xhigh"
+}


### PR DESCRIPTION
Pins the committed Claude Code session floor for this repo:

- `"model": "opus"`
- `"effortLevel": "xhigh"`

This is the cross-repo rollout of the effort/model floor established in
command-center (TC-CC623) and the bootstrap-orchestrator pilot, tracked by
**TC-CC624** (FIND-248 §would_have_prevented (c)). Carrying the floor in git
means every host runs this repo's sessions at the pinned model + effort by
default instead of the un-pinned model-default.

Additive and reversible: only the two keys are added; any existing settings
blocks are preserved. `xhigh` is the committable floor (`max` is a per-host /
per-launch concern per FIND-248 / TC-CC455).

Part of the TC-CC624 cross-repo cascade rollout. Opened as **draft** for
per-increment operator verification.